### PR TITLE
fix: resolve 4 confirmed bugs (#186, #187, #132, #156)

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CI_LLM_PROVIDER: azure_openai
+      WARDEN_LLM_PROVIDER: azure_openai
 
 
     steps:

--- a/src/warden/llm/config.py
+++ b/src/warden/llm/config.py
@@ -330,6 +330,13 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
     # Determine explicit provider override — env var takes precedence over config.yaml.
     # This allows CI to override local defaults (e.g. WARDEN_LLM_PROVIDER=groq in CI
     # while config.yaml has provider: claude_code for local development).
+    # If running in CI and config.yaml has a llm.ci subsection, merge it so that
+    # `warden config llm edit` CI tab settings take effect.
+    is_ci = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
+    if is_ci and config_override and "ci" in config_override:
+        ci_overrides = config_override.pop("ci")
+        config_override = {**config_override, **ci_overrides}
+
     explicit_provider_override = None
     env_provider = os.environ.get("WARDEN_LLM_PROVIDER", "").strip().lower()
     if env_provider:

--- a/src/warden/pipeline/application/orchestrator/dependency_checker.py
+++ b/src/warden/pipeline/application/orchestrator/dependency_checker.py
@@ -138,6 +138,4 @@ class DependencyChecker:
             else:
                 return False
 
-        if current is None:
-            return False
-        return not (isinstance(current, (list, dict)) and len(current) == 0)
+        return current is not None

--- a/src/warden/reports/generator.py
+++ b/src/warden/reports/generator.py
@@ -407,14 +407,15 @@ class ReportGenerator:
                 location_str = self._get_val(finding, "location", "unknown")
                 file_path = location_str.split(":")[0] if ":" in location_str else location_str
 
-                # Log if critical attributes are missing
-                if not rule_id or not location_str:
+                # Skip malformed findings that would produce invalid SARIF entries
+                if not rule_id or not location_str or location_str == "unknown":
                     logger.warning(
-                        "sarif_finding_missing_critical_attributes",
+                        "sarif_skipping_malformed_finding",
                         finding_id=rule_id,
                         location=location_str,
                         frame_id=frame_id,
                     )
+                    continue
 
                 # Register rule if not seen
                 if rule_id not in rules_map:


### PR DESCRIPTION
## Summary

Fixes 4 confirmed bugs after verifying each against the actual codebase (5 others were false positives).

### Changes

- **fix(ci): `CI_LLM_PROVIDER` → `WARDEN_LLM_PROVIDER` in `warden.yml`** — Closes #186
  The workflow used an env var that is never read by the codebase, silently falling back to the local config provider on every main-branch push scan.

- **fix(config): consume `llm.ci` subsection in `load_llm_config` when running in CI** — Closes #187
  When `CI=true` or `GITHUB_ACTIONS` is set, the `llm.ci` block is now merged over the top-level `llm` config. Previously, `warden config llm edit` CI tab settings had zero effect during CI scans.

- **fix(dependency_checker): empty list/dict is "present", not "missing"** — Closes #132
  `_context_attr_exists` returned `False` for empty collections, causing frames that depend on legitimately-empty context attributes (e.g. `project_context` on projects with no detected patterns) to be incorrectly skipped with a misleading "Required context not available" message.

- **fix(sarif): skip malformed findings instead of writing invalid SARIF entries** — Closes #156
  Findings with a missing `rule_id`, empty `location`, or `"unknown"` location were written to SARIF after only logging a warning. GitHub's SARIF upload API can reject the entire file on malformed entries or silently drop legitimate findings. Added `continue` guard.

### False Positives Identified

After code inspection and test runs, the following reported issues were not reproducible:
- #176 — `html.escape()` is already scoped to the LLM prompt string only, never stored back to findings
- #130 — Both `SecurityFrame` and `ResilienceFrame` already filter `prior_findings` by `code_file.path`
- #134 — `property_frame._parse_batch_llm_response` already calls `json.loads` before passing to `from_json`
- #137 — Pydantic v2 auto-coerces `"300"` strings to `int` for `int | None` fields
- #129 — Python's `finally` guarantees `ensure_state_consistency` runs before any `return`

## Test plan

- [x] `tests/pipeline/` — all passing
- [x] `tests/llm/` — all passing
- [x] `tests/reports/` — all passing
- [x] Pre-existing failure in `tests/integration/test_context_propagation.py` is unrelated (classification cache mock issue, pre-dates this PR)