### PR TITLE
fix(lint): resolve 8 ruff CI errors (RUF100, C420, I001, UP037, SIM110)

### DIFF
--- a/src/warden/analysis/application/data_dependency_builder.py
+++ b/src/warden/analysis/application/data_dependency_builder.py
@@ -68,10 +68,7 @@ def _is_fp_field(field_name: str) -> bool:
     Returns:
         ``True`` when the field should be ignored.
     """
-    for pattern in FP_FIELD_PATTERNS:
-        if field_name.startswith(pattern) or pattern in field_name:
-            return True
-    return False
+    return any(field_name.startswith(pattern) or pattern in field_name for pattern in FP_FIELD_PATTERNS)
 
 
 # ---------------------------------------------------------------------------

--- a/src/warden/classification/application/heuristic_classifier.py
+++ b/src/warden/classification/application/heuristic_classifier.py
@@ -154,7 +154,7 @@ class HeuristicClassifier:
 
     @staticmethod
     def classify(
-        code_files: list["CodeFile"],
+        code_files: list[CodeFile],
         available_frame_ids: list[str],
     ) -> HeuristicResult:
         """

--- a/src/warden/mcp/infrastructure/adapters/cleanup_adapter.py
+++ b/src/warden/mcp/infrastructure/adapters/cleanup_adapter.py
@@ -8,11 +8,10 @@ Maps to gRPC CleanupMixin functionality.
 from pathlib import Path
 from typing import Any
 
-from warden.shared.utils.language_utils import get_code_extensions
-
 from warden.mcp.domain.enums import ToolCategory
 from warden.mcp.domain.models import MCPToolDefinition, MCPToolResult
 from warden.mcp.infrastructure.adapters.base_adapter import BaseWardenAdapter
+from warden.shared.utils.language_utils import get_code_extensions
 from warden.shared.utils.path_utils import sanitize_path
 
 

--- a/src/warden/mcp/infrastructure/adapters/fortification_adapter.py
+++ b/src/warden/mcp/infrastructure/adapters/fortification_adapter.py
@@ -8,11 +8,10 @@ Maps to gRPC FortificationMixin functionality.
 from pathlib import Path
 from typing import Any
 
-from warden.shared.utils.language_utils import get_code_extensions
-
 from warden.mcp.domain.enums import ToolCategory
 from warden.mcp.domain.models import MCPToolDefinition, MCPToolResult
 from warden.mcp.infrastructure.adapters.base_adapter import BaseWardenAdapter
+from warden.shared.utils.language_utils import get_code_extensions
 
 
 class FortificationAdapter(BaseWardenAdapter):

--- a/src/warden/validation/frames/async_race/async_race_frame.py
+++ b/src/warden/validation/frames/async_race/async_race_frame.py
@@ -106,7 +106,7 @@ class AsyncRaceFrame(ValidationFrame):
     def frame_id(self) -> str:
         return "async_race"
 
-    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:  # noqa: ARG002
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Scan a single file for async race condition candidates.
 

--- a/src/warden/validation/frames/protocol_breach/protocol_breach_frame.py
+++ b/src/warden/validation/frames/protocol_breach/protocol_breach_frame.py
@@ -83,7 +83,7 @@ class ProtocolBreachFrame(ValidationFrame):
     def frame_id(self) -> str:
         return "protocol_breach"
 
-    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:  # noqa: ARG002
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Run protocol breach analysis.
 
@@ -245,7 +245,7 @@ class ProtocolBreachFrame(ValidationFrame):
         try:
             source = frame_runner_path.read_text(encoding="utf-8")
         except OSError:
-            return {m: False for m in _MIXIN_PROTOCOL}
+            return dict.fromkeys(_MIXIN_PROTOCOL, False)
 
         status: dict[str, bool] = {}
         for mixin_name, setter_method in _MIXIN_PROTOCOL.items():

--- a/src/warden/validation/frames/stale_sync/stale_sync_frame.py
+++ b/src/warden/validation/frames/stale_sync/stale_sync_frame.py
@@ -104,7 +104,7 @@ class StaleSyncFrame(ValidationFrame, DataFlowAware):
         """Inject the DataDependencyGraph into this frame."""
         self._ddg = ddg
 
-    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:  # noqa: ARG002
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Run STALE_SYNC analysis.
 


### PR DESCRIPTION
## Summary

Fixes all 8 ruff errors blocking CI in run [#22418210507](https://github.com/alperduzgun/warden-core/actions/runs/22418210507).

## Changes

| File | Rule | Fix |
|------|------|-----|
| `stale_sync_frame.py:107` | `RUF100` | Remove `# noqa: ARG002` — rule not enabled in config |
| `protocol_breach_frame.py:86` | `RUF100` | Remove `# noqa: ARG002` — rule not enabled in config |
| `async_race_frame.py:109` | `RUF100` | Remove `# noqa: ARG002` — rule not enabled in config |
| `protocol_breach_frame.py:248` | `C420` | `{m: False for m in x}` → `dict.fromkeys(x, False)` |
| `fortification_adapter.py:8` | `I001` | Sort imports — `language_utils` moved to correct group |
| `cleanup_adapter.py:8` | `I001` | Sort imports — `language_utils` moved to correct group |
| `heuristic_classifier.py:157` | `UP037` | Remove string quotes from `list["CodeFile"]` (covered by `from __future__ import annotations`) |
| `data_dependency_builder.py:71` | `SIM110` | for-loop early-return → `return any(...)` |

## Verification

```
ruff check <all 7 files> → All checks passed!
```