### PR TITLE
fix(classification): remove dead dict literal in generate_suppression_rules

### DIFF
--- a/src/warden/classification/application/llm_classification_phase.py
+++ b/src/warden/classification/application/llm_classification_phase.py
@@ -283,11 +283,6 @@ FILES TO ANALYZE:
         if not findings:
             return []
 
-        {
-            "findings": findings[:50],  # Limit for token count
-            "file_contexts": file_contexts,
-        }
-
         prompt = f"""Analyze these findings and identify false positives to suppress:
 
 FINDINGS:


### PR DESCRIPTION
Closes #193

The dict literal `{'findings': findings[:50], 'file_contexts': file_contexts}` at lines 286-289 was constructed and immediately garbage-collected — a refactor leftover where the variable assignment was removed but the body stayed. The downstream prompt already references `findings` and `file_contexts` directly, so no logic is affected.