### PR TITLE
fix(suppression): replace fnmatch with Path.match() to support ** recursive glob

### DIFF
--- a/src/warden/pipeline/application/orchestrator/suppression_filter.py
+++ b/src/warden/pipeline/application/orchestrator/suppression_filter.py
@@ -4,7 +4,7 @@ Suppression filtering for validation frames.
 Handles configuration-based suppression of findings.
 """
 
-import fnmatch
+from pathlib import Path
 from typing import Any
 
 from warden.shared.infrastructure.logging import get_logger
@@ -58,7 +58,7 @@ class SuppressionFilter:
 
                 if f_path:
                     for pattern in file_patterns:
-                        if fnmatch.fnmatch(f_path, pattern):
+                        if Path(f_path).match(pattern):
                             matched_file = True
                             break
 


### PR DESCRIPTION
Closes #118

`fnmatch.fnmatch()` does not support `**` recursive glob. Patterns like `**/legacy/**/*.py` silently matched nothing, so findings in subdirectories were never suppressed.

`pathlib.Path.match()` supports `**` correctly and is available in Python 3.10+ (already required).