### PR TITLE
fix(ci): exit code now fails on blocker violations from custom security rules

### DIFF
--- a/src/warden/cli/commands/scan.py
+++ b/src/warden/cli/commands/scan.py
@@ -1640,10 +1640,17 @@ async def _run_scan_async(
 
         critical_count = final_result_data.get("critical_findings", 0) if final_result_data else 0
         frames_failed = final_result_data.get("frames_failed", 0) if final_result_data else 0
+        blocker_violations = final_result_data.get("blocker_violations", 0) if final_result_data else 0
 
         if not pipeline_ok:
             console.print("[bold red]❌ Pipeline did not complete successfully.[/bold red]")
             return 1
+
+        if blocker_violations > 0:
+            console.print(
+                f"[bold red]❌ Scan failed: {blocker_violations} custom rule blocker violation(s).[/bold red]"
+            )
+            return 2  # Exit code 2: Policy Failure (Blocker rule violated)
 
         if critical_count > 0:
             console.print(f"[bold red]❌ Scan failed: {critical_count} critical issues found.[/bold red]")

--- a/src/warden/pipeline/domain/models.py
+++ b/src/warden/pipeline/domain/models.py
@@ -270,6 +270,9 @@ class PipelineResult(BaseDomainModel):
     artifacts: list[dict[str, Any]] = Field(default_factory=list)
     quality_score: float = 0.0
 
+    # Blocker violations from custom rules (is_blocker: true)
+    blocker_violations: int = 0
+
     # LLM Usage
     total_tokens: int = 0
     prompt_tokens: int = 0
@@ -294,6 +297,9 @@ class PipelineResult(BaseDomainModel):
 
         # Include findings list
         data["findings"] = self.findings
+
+        # Blocker violations count (custom rules with is_blocker: true)
+        data["blocker_violations"] = self.blocker_violations
 
         # Add token usage
         data["llmUsage"] = {


### PR DESCRIPTION
Closes #103

Custom rules with `is_blocker: true` produced violations in `pre_violations`/`post_violations` on each frame result, but these never flowed into exit code calculation. A scan hitting a hardcoded-secret or banned-import rule would silently return exit 0 in CI.

**Three-part fix:**
1. `PipelineResult` gets a new `blocker_violations: int` field
2. `PipelineResultBuilder` counts `is_blocker` violations from all frame result violation lists
3. `scan.py` checks `blocker_violations > 0` before `critical_findings` → exit 2