### PR TITLE
fix(config): yaml_parser imports CustomRule from rules.domain.models (full schema)

### DIFF
--- a/src/warden/config/yaml_parser.py
+++ b/src/warden/config/yaml_parser.py
@@ -41,7 +41,6 @@ from typing import Any
 import yaml
 
 from warden.config.domain.models import (
-    CustomRule,
     PipelineConfig,
     PipelineEdge,
     PipelineNode,
@@ -49,6 +48,7 @@ from warden.config.domain.models import (
     Position,
     ProjectSummary,
 )
+from warden.rules.domain.models import CustomRule
 from warden.validation.domain.frame import get_frame_by_id
 
 


### PR DESCRIPTION
## Summary
- `yaml_parser.py` imported `CustomRule` from `warden.config.domain.models` (only `id/content/severity`)
- It created instances with `name`, `category`, `is_blocker`, `description`, `type`, `conditions` — fields that don't exist in the simplified model
- Fix: import from `warden.rules.domain.models` which has the full rule schema

## Root Cause
Two classes named `CustomRule` exist: a Panel-facing simplified model (`config.domain`) and the full domain model (`rules.domain`). The parser needs the full version but imported the wrong one. Pydantic silently ignores extra fields, masking the `content` field validation failure.

Closes #115