### PR TITLE
fix(fortification): enforce finding_id in prompt + escalate unlinked fix patches to ERROR

### DIFF
--- a/src/warden/fortification/application/prompt_builder.py
+++ b/src/warden/fortification/application/prompt_builder.py
@@ -90,7 +90,8 @@ TASK: Fix {issue_type} vulnerabilities.
 ISSUES:
 {"".join(issue_details)}
 
-OUTPUT JSON: [{{ "title": "...", "detail": "...", "code": "...", "auto_fixable": bool }}]
+OUTPUT JSON: [{{"finding_id": "<exact input id>", "title": "...", "detail": "...", "code": "...", "auto_fixable": bool}}]
+CRITICAL: finding_id MUST exactly match one of the input ids. Do not invent, truncate, or modify ids.
 Fix must match project style.
 """
         return prompt

--- a/src/warden/pipeline/application/executors/fortification_executor.py
+++ b/src/warden/pipeline/application/executors/fortification_executor.py
@@ -209,11 +209,21 @@ class FortificationExecutor(BasePhaseExecutor):
                     # BATCH 3: Track unlinked fortifications
                     unlinked_count += 1
                     unlinked_ids.append(fid)
-                    logger.warning(
+                    logger.error(
                         "fortification_unlinked",
                         fortification_id=fid,
                         reason="finding_not_in_map",
+                        hint="LLM may have modified the finding_id — patch silently dropped (#135)",
                     )
+
+            # Post-LLM validation: alert when fixes were silently dropped (#135)
+            if unlinked_count > 0:
+                logger.error(
+                    "fortification_linking_incomplete",
+                    linked=linked_count,
+                    unlinked=unlinked_count,
+                    unlinked_ids=unlinked_ids[:10],
+                )
 
             # Add phase result (BATCH 3: Include linking metrics)
             total_forts = len(result.fortifications)


### PR DESCRIPTION
## Summary
- Add `finding_id MUST exactly match the input id` constraint to the LLM output schema in `prompt_builder.py`
- Change `fortification_unlinked` log from `warning` to `error` so dropped patches are visible
- Add `fortification_linking_incomplete` error summary after all fortifications are processed

## Root Cause
The LLM prompt only asked for `title/detail/code/auto_fixable` — it never asked for `finding_id`. When the LLM invented or modified IDs, the executor silently dropped those fixes at WARNING level with no aggregate summary.

Closes #135