### PR TITLE
fix(llm): OfflineClient.complete_async passes proper LlmRequest instead of None

### DIFF
--- a/src/warden/llm/providers/offline.py
+++ b/src/warden/llm/providers/offline.py
@@ -38,7 +38,8 @@ class OfflineClient(ILlmClient):
     async def complete_async(
         self, prompt: str, system_prompt: str = "", model: str | None = None, use_fast_tier: bool = False
     ) -> LlmResponse:
-        return await self.send_async(None)
+        # Satisfy the LlmRequest type contract instead of passing None (#210)
+        return await self.send_async(LlmRequest(system_prompt=system_prompt, user_message=prompt))
 
     async def analyze_security_async(self, code_content: str, language: str, use_fast_tier: bool = False) -> dict:
         """


### PR DESCRIPTION
## Summary
- `complete_async` was calling `send_async(None)` which violates the `ILlmClient` type contract
- Fix: construct a minimal `LlmRequest(system_prompt=..., user_message=...)` from the provided parameters

## Root Cause
`send_async(request: LlmRequest)` currently ignores its argument but future additions (logging, metrics, model selection) would trigger `AttributeError` on `None`. The type violation also causes static analysis failures.

Closes #210