### PR TITLE
fix(llm): increase LlmRequest default timeout from 60s to 90s

### DIFF
--- a/src/warden/llm/types.py
+++ b/src/warden/llm/types.py
@@ -37,7 +37,7 @@ class LlmRequest(BaseDomainModel):
     model: str | None = None
     temperature: float = 0.0  # Idempotency: deterministic outputs
     max_tokens: int = 4000
-    timeout_seconds: int = 60
+    timeout_seconds: float = 90.0
     use_fast_tier: bool = False  # If True, use local/fast model if available
 
 


### PR DESCRIPTION
## Summary
- Changes `LlmRequest.timeout_seconds: int = 60` → `timeout_seconds: float = 90.0`
- Large files analysed by local Ollama models (7b+ or even 0.5b on CPU) commonly exceed 60s first-token latency, causing spurious `retry_exhausted` errors
- The outer `@resilient(timeout_seconds=120.0)` on `OllamaClient.send_async` was irrelevant because the HTTP connection itself timed out first

## Test plan
- [ ] Run scan against a large file (>500 lines) with Ollama — no timeout errors
- [ ] Remote provider (Groq/OpenAI) still uses 90s which is within their limits

Closes #191