### PR TITLE
fix(pipeline): skip fortification and cleaning in CI mode

### DIFF
--- a/src/warden/pipeline/application/orchestrator/pipeline_phase_runner.py
+++ b/src/warden/pipeline/application/orchestrator/pipeline_phase_runner.py
@@ -54,6 +54,12 @@ class PipelinePhaseRunner:
     ) -> None:
         """Execute all pipeline phases in order."""
 
+        # In CI mode, skip expensive LLM-heavy phases that add no value to CI results
+        if getattr(self.config, "ci_mode", False):
+            self.config.enable_fortification = False
+            self.config.enable_cleaning = False
+            logger.info("ci_mode_active", skipped_phases=["fortification", "cleaning"])
+
         # Phase 0: PRE-ANALYSIS
         context.current_phase = "Pre-Analysis"
         if self._progress_callback:


### PR DESCRIPTION
## Summary
- `ci_mode=True` was set when `--ci` flag passed, but `pipeline_phase_runner.py` never read this flag to skip expensive phases
- Fortification and cleaning ran in CI regardless, adding ~3 minutes of LLM-heavy processing with no actionable output for CI users

## Fix
At the start of `execute_all_phases()`, if `ci_mode=True`:
- `enable_fortification = False`
- `enable_cleaning = False`
- Logs `ci_mode_active` with `skipped_phases` for observability

Expected CI scan time reduction: ~5 minutes → ~2 minutes for default configs.

## Test plan
- [ ] Run scan with `--ci` flag — verify fortification and cleaning phases are skipped in logs
- [ ] Run scan without `--ci` — verify fortification/cleaning still execute when enabled

Closes #157