### PR TITLE
fix(ci): correct shell substitution and non-existent --update-baseline flag

### DIFF
--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Full Scan and Update Baseline
         run: |
           mkdir -p .warden/reports
-          warden scan --update-baseline --format sarif --output .warden/reports/warden-report.sarif
+          warden scan --format sarif --output .warden/reports/warden-report.sarif
 
       - name: Check Technical Debt
         run: warden baseline debt

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -50,7 +50,7 @@ jobs:
           # CI mode with diff - only scan changed files
           # Output SARIF for GitHub Code Scanning integration
           mkdir -p .warden/reports
-          warden scan --ci --diff --base ${ github.base_ref } --format sarif --output .warden/reports/warden-report.sarif
+          warden scan --ci --diff --base ${{ github.base_ref }} --format sarif --output .warden/reports/warden-report.sarif
 
       - name: Upload SARIF Report
         if: always()


### PR DESCRIPTION
## Summary
Two CI workflow bugs that caused 100% failure rate on critical paths:

### #230 — warden-pr.yml: bad shell substitution
- `${ github.base_ref }` (single brace) → bash bad substitution error
- Every PR diff scan failed immediately — zero security coverage on PRs
- Fix: `${{ github.base_ref }}`

### #231 — warden-nightly.yml: non-existent CLI flag
- `warden scan --update-baseline` → `No such option` error (exit code 2)
- Nightly full scan never completed — baseline drift accumulated silently
- Fix: removed the flag (baseline update is enabled by default)

## Chaos Lens
Both failures are **silent contract breaks** — CI reported failure but no
alert mechanism flagged the security gate was disabled. Single-point-of-failure
typos with outsized blast radius.

## Test plan
- [ ] PR scan runs successfully and uploads SARIF
- [ ] Nightly scan completes and commits updated baseline

Closes #230
Closes #231