### PR TITLE
fix(baseline): sync context.validated_issues after baseline filtering

### DIFF
--- a/src/warden/pipeline/application/orchestrator/findings_post_processor.py
+++ b/src/warden/pipeline/application/orchestrator/findings_post_processor.py
@@ -289,6 +289,26 @@ class FindingsPostProcessor:
                         all_findings.extend(res.findings)
                 context.findings = all_findings
 
+                # CRITICAL: sync validated_issues so downstream phases
+                # (Fortification, SARIF) operate on the filtered set.
+                # Without this, fortification generates patches for
+                # findings the user already accepted as technical debt.
+                # validated_issues holds dicts, so match by rule_id:path key.
+                if hasattr(context, "validated_issues") and context.validated_issues:
+                    before_count = len(context.validated_issues)
+                    context.validated_issues = [
+                        vf
+                        for vf in context.validated_issues
+                        if f"{vf.get('rule_id') or vf.get('check_id')}:"
+                        f"{self._normalize_path(vf.get('file_path') or vf.get('path', ''))}" not in known_issues
+                    ]
+                    logger.info(
+                        "baseline_validated_issues_synced",
+                        before=before_count,
+                        after=len(context.validated_issues),
+                        suppressed=before_count - len(context.validated_issues),
+                    )
+
         except Exception as e:
             logger.warning("baseline_application_failed", error=str(e))
 


### PR DESCRIPTION
## Summary
**Silent state corruption bug**: `apply_baseline()` filtered `context.findings` but left `context.validated_issues` in its pre-baseline state.

## Data chain (before fix)
```
Phase 3 → result_aggregator → context.validated_issues = [A, B, C, D]
apply_baseline() → removes A (baseline-known)
context.findings = [B, C, D]           ✓
context.validated_issues = [A, B, C, D] ✗ (A still present)
↓
FortificationExecutor reads validated_issues
→ generates fix patch for A (user already accepted as tech debt)
→ SARIF may include A in output
```

## Fix
After baseline filtering, sync `validated_issues` using the same `known_issues` set (rule_id:rel_path keys). `validated_issues` holds dicts so identity matching is by dict fields, not object identity.

Logs `baseline_validated_issues_synced` with before/after counts for observability.

## Chaos Lens
State mutation that doesn't propagate → two sources of truth diverge silently. Every downstream consumer (Fortification, SARIF, MCP) made decisions on stale data.

## Test plan
- [ ] Scan with baseline containing finding X → fortification should NOT generate patch for X
- [ ] `baseline_validated_issues_synced` logged with correct suppressed count
- [ ] `validated_issues` count equals `findings` count after baseline applied

Closes #124