### PR TITLE
ci: standardize Ollama model to qwen2.5-coder:0.5b across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,14 +214,14 @@ jobs:
         env:
           # Configuration for Hybrid LLM Architecture
           # Smart Tier: Groq (fast cloud API, no token cost issues)
-          # Fast/Local Tier: Ollama qwen2.5-coder:3b (free, local fallback)
+          # Fast/Local Tier: Ollama qwen2.5-coder:0.5b (free, local fallback)
 
           # Secrets
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 
           # Warden Configuration
           WARDEN_LLM_PROVIDER: "groq"         # Smart Tier: Groq (overrides config.yaml's claude_code)
-          WARDEN_FAST_TIER_PRIORITY: "ollama"  # Fast/Local Tier: Ollama qwen2.5-coder:3b
+          WARDEN_FAST_TIER_PRIORITY: "ollama"  # Fast/Local Tier: Ollama qwen2.5-coder:0.5b
           WARDEN_LLM_CONCURRENCY: "5"          # Conservative for Groq rate limits
 
           # Local Service Config
@@ -265,11 +265,11 @@ jobs:
           
           echo "Checking for existing models..."
           ollama list # Verify models visible to the server
-          if ollama list | grep -q "qwen2.5-coder:3b"; then
-            echo "✅ Model qwen2.5-coder:3b already cached."
+          if ollama list | grep -q "qwen2.5-coder:0.5b"; then
+            echo "✅ Model qwen2.5-coder:0.5b already cached."
           else
             echo "⬇️ Model not found in cache. Pulling..."
-            ollama pull qwen2.5-coder:3b
+            ollama pull qwen2.5-coder:0.5b
           fi
           
           # --- SCAN EXECUTION ---

--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:3b
+          ollama pull qwen2.5-coder:0.5b
 
 
       - name: Refresh Intelligence

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:3b
+          ollama pull qwen2.5-coder:0.5b
 
 
       - name: Run Warden PR Scan

--- a/.github/workflows/warden-release.yml
+++ b/.github/workflows/warden-release.yml
@@ -46,7 +46,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:3b
+          ollama pull qwen2.5-coder:0.5b
 
 
       - name: Refresh Intelligence


### PR DESCRIPTION
## Problem

`generate-baseline.yml` was updated to `qwen2.5-coder:0.5b` in PR #238 but 4 other workflows still referenced `qwen2.5-coder:3b`:

| File | Location | Before | After |
|------|----------|--------|-------|
| `warden-nightly.yml` | line 45 | `3b` | `0.5b` |
| `warden-pr.yml` | line 45 | `3b` | `0.5b` |
| `warden-release.yml` | line 49 | `3b` | `0.5b` |
| `ci.yml` | lines 217, 224, 268, 269, 272 | `3b` | `0.5b` |

## Why 0.5b

- **10x faster inference** on CI runners (no GPU)
- **Avoids 60s+ first-token latency** that caused `retry_exhausted` errors  
- **Same task quality** for fast-tier routing decisions (triage, not deep analysis)
- `3b` on CPU in CI regularly exceeded the previous 60s HTTP timeout (now 90s per #228, but 0.5b is still safer)

## Verification

```bash
grep -rn "qwen" .github/workflows/
# All occurrences → qwen2.5-coder:0.5b ✓
```