### PR TITLE
revert(ci): restore qwen2.5-coder:3b in non-baseline workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,14 +214,14 @@ jobs:
         env:
           # Configuration for Hybrid LLM Architecture
           # Smart Tier: Groq (fast cloud API, no token cost issues)
-          # Fast/Local Tier: Ollama qwen2.5-coder:0.5b (free, local fallback)
+          # Fast/Local Tier: Ollama qwen2.5-coder:3b (free, local fallback)
 
           # Secrets
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
 
           # Warden Configuration
           WARDEN_LLM_PROVIDER: "groq"         # Smart Tier: Groq (overrides config.yaml's claude_code)
-          WARDEN_FAST_TIER_PRIORITY: "ollama"  # Fast/Local Tier: Ollama qwen2.5-coder:0.5b
+          WARDEN_FAST_TIER_PRIORITY: "ollama"  # Fast/Local Tier: Ollama qwen2.5-coder:3b
           WARDEN_LLM_CONCURRENCY: "5"          # Conservative for Groq rate limits
 
           # Local Service Config
@@ -265,11 +265,11 @@ jobs:
           
           echo "Checking for existing models..."
           ollama list # Verify models visible to the server
-          if ollama list | grep -q "qwen2.5-coder:0.5b"; then
-            echo "✅ Model qwen2.5-coder:0.5b already cached."
+          if ollama list | grep -q "qwen2.5-coder:3b"; then
+            echo "✅ Model qwen2.5-coder:3b already cached."
           else
             echo "⬇️ Model not found in cache. Pulling..."
-            ollama pull qwen2.5-coder:0.5b
+            ollama pull qwen2.5-coder:3b
           fi
           
           # --- SCAN EXECUTION ---

--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:0.5b
+          ollama pull qwen2.5-coder:3b
 
 
       - name: Refresh Intelligence

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:0.5b
+          ollama pull qwen2.5-coder:3b
 
 
       - name: Run Warden PR Scan

--- a/.github/workflows/warden-release.yml
+++ b/.github/workflows/warden-release.yml
@@ -46,7 +46,7 @@ jobs:
             echo "Attempt $i/30: Ollama not ready yet..."
             sleep 1
           done
-          ollama pull qwen2.5-coder:0.5b
+          ollama pull qwen2.5-coder:3b
 
 
       - name: Refresh Intelligence


### PR DESCRIPTION
## Problem

PR #242 bulk-replaced all `qwen2.5-coder:3b` → `0.5b` across every workflow. This was incorrect — the 0.5b optimization was only warranted for `generate-baseline.yml` (fixed in #238), where the specific issue was 60s+ inference timeout during triage.

## Correction

Restored `qwen2.5-coder:3b` in 4 workflows that serve different purposes:

| Workflow | Purpose | Why 3b is correct |
|----------|---------|-------------------|
| `warden-nightly.yml` | Full nightly scan + baseline | Needs quality analysis, no tight time SLA |
| `warden-pr.yml` | PR security gate | Diff is small; 3b quality matters for accuracy |
| `warden-release.yml` | Strict pre-release audit | Highest quality scan |
| `ci.yml` | CI validation + cache logic | Standard CI scan, 3b is acceptable |

`generate-baseline.yml` stays at `0.5b` — that workflow pulls 500+ files through triage where speed is the primary concern and the 60s timeout was the reported pain point.