### PR TITLE
ci: remove groq from WARDEN_BLOCKED_PROVIDERS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Verify Code Intelligence (Audit Context)
         env:
           WARDEN_LLM_PROVIDER: "ollama"
-          WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+          WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
         run: |
           echo "Generating Code Intelligence and Context Graphs..."
           warden refresh --force
@@ -216,7 +216,7 @@ jobs:
 
           # Warden Configuration
           WARDEN_LLM_PROVIDER: "ollama"
-          WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+          WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
           WARDEN_LLM_CONCURRENCY: "2"          # Conservative for local Ollama
 
           # Local Service Config

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -96,7 +96,7 @@ jobs:
       env:
         # Local Ollama only — no cloud API dependency, no rate limits
         WARDEN_LLM_PROVIDER: "ollama"
-        WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+        WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
         WARDEN_LLM_CONCURRENCY: ${{ inputs.concurrency || '2' }}
       run: |
         # Use input values or defaults for scheduled runs

--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
     env:
       WARDEN_LLM_PROVIDER: ollama
-      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
 
     steps:

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -11,7 +11,7 @@ jobs:
 
     env:
       WARDEN_LLM_PROVIDER: ollama
-      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
 
     steps:

--- a/.github/workflows/warden-release.yml
+++ b/.github/workflows/warden-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       WARDEN_LLM_PROVIDER: ollama
-      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
 
     steps:

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       WARDEN_LLM_PROVIDER: ollama
-      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex,groq"
+      WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
 
 


### PR DESCRIPTION
Groq is already excluded by the absence of `GROQ_API_KEY` in all scan workflows. Explicitly blocking it in `WARDEN_BLOCKED_PROVIDERS` is redundant.