### PR TITLE
fix(ci): pre-install semantic extras, fix ci config groq -> ollama

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       # Rust is pre-installed on ubuntu-latest. We only cache the artifacts.
       - name: Cache Rust
@@ -154,13 +155,10 @@ jobs:
           workspaces: src/warden_rust
           shared-key: "rust-warden-scan"
 
-      # Removed apt-get install as build-essential is pre-installed on ubuntu-latest
-      # and it saves ~1-2 minutes of setup time.
-
       - name: Install Warden
         run: |
           pip install --upgrade pip
-          pip install .
+          pip install ".[semantic]"
           # Verify installation
           warden --help
 

--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Warden
-        run: pip install warden-core
+        run: pip install "warden-core[semantic]"
 
       - name: Setup Ollama
         run: |

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Warden
-        run: pip install warden-core
+        run: pip install "warden-core[semantic]"
 
       - name: Setup Ollama
         run: |

--- a/.github/workflows/warden-release.yml
+++ b/.github/workflows/warden-release.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Warden
-        run: pip install warden-core
+        run: pip install "warden-core[semantic]"
 
       - name: Setup Ollama
         run: |

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -34,7 +34,7 @@ jobs:
           cache: 'pip'
 
       - name: Install Warden
-        run: pip install .
+        run: pip install ".[semantic]"
 
       - name: Setup Ollama
         run: |

--- a/.warden/config.yaml
+++ b/.warden/config.yaml
@@ -121,12 +121,12 @@ llm:
   smart_model: qwen2.5-coder:3b
   fast_model: qwen2.5-coder:3b
   ci:
-    provider: groq
-    smart_model: ''
-    model: ''
+    provider: ollama
+    smart_model: qwen2.5-coder:3b
+    model: qwen2.5-coder:3b
     fast_tier_providers:
-    - groq
-    fast_model: ''
+    - ollama
+    fast_model: qwen2.5-coder:3b
 project:
   description: Warden configuration for warden-core
   detected_at: '2025-12-24T16:35:53.922859'


### PR DESCRIPTION
## Problem 1: chromadb/sentence-transformers her run'da yükleniyor

CI'da \`pip install .\` yapılıyor, \`.[semantic]\` değil. \`auto_resolver\` runtime'da \`pip install chromadb\` ve \`pip install sentence-transformers\` çalıştırıyordu.

**Fix:** Tüm workflow'larda \`[semantic]\` extra eklendi.

## Problem 2: \`fast_tier_client_creation_failed provider=groq\` warning

\`.warden/config.yaml\` \`ci:\` bloğu \`fast_tier_providers: [groq]\` içeriyordu. \`WARDEN_LLM_PROVIDER=ollama\` env var primary provider'ı override ediyordu ama \`ci.fast_tier_providers\` listesini değil.

**Fix:** \`config.yaml\` ci bölümü ollama'ya güncellendi.