### PR TITLE
perf(ci): eliminate Ollama triage timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
           restore-keys: |
             warden-storage-${{ runner.os }}-
 
+      - name: Cache Warden Triage & Findings
+        uses: actions/cache@v5
+        with:
+          path: .warden/cache/
+          key: warden-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            warden-cache-${{ runner.os }}-
+
       - name: Cache AI Models
         uses: actions/cache@v5
         with:
@@ -217,8 +225,12 @@ jobs:
           WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
           WARDEN_LLM_CONCURRENCY: "2"          # Conservative for local Ollama
 
-          # Local Service Config
+          # Ollama CPU Optimization
           OLLAMA_HOST: http://localhost:11434
+          OLLAMA_NUM_THREADS: "2"              # Match CI runner core count
+          OLLAMA_MAX_LOADED_MODELS: "1"        # No multi-model RAM overhead
+          OLLAMA_FLASH_ATTENTION: "1"          # Reduces KV cache memory pressure
+          OLLAMA_CONTEXT_LENGTH: "4096"        # Triage prompts ~2K; 4K is safe, 32K wastes RAM
 
           # Git ref for incremental scan (env var to prevent script injection)
           BASE_REF: ${{ github.base_ref || 'main' }}
@@ -264,7 +276,16 @@ jobs:
             echo "⬇️ Model not found in cache. Pulling..."
             ollama pull qwen2.5-coder:3b
           fi
-          
+
+          # Warm-up: load model into RAM and pin it for the entire job.
+          # keep_alive=-1 prevents Ollama from unloading the model between requests.
+          # This eliminates the 15-30s cold-start on the first triage batch.
+          echo "Warming up model (pinning to RAM)..."
+          curl -s http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5-coder:3b","prompt":"","keep_alive":-1}' \
+            -o /dev/null
+          echo "✅ Model warm and ready."
+
           # --- SCAN EXECUTION ---
           
           # Determine scan strategy: Baseline (first run) or Incremental (subsequent runs)

--- a/.github/workflows/warden-nightly.yml
+++ b/.github/workflows/warden-nightly.yml
@@ -15,6 +15,10 @@ jobs:
       WARDEN_LLM_PROVIDER: ollama
       WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
+      OLLAMA_NUM_THREADS: "2"
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_FLASH_ATTENTION: "1"
+      OLLAMA_CONTEXT_LENGTH: "4096"
 
     steps:
       - name: Checkout Code
@@ -28,6 +32,14 @@ jobs:
 
       - name: Install Warden
         run: pip install "warden-core[semantic]"
+
+      - name: Cache Warden Triage & Findings
+        uses: actions/cache@v5
+        with:
+          path: .warden/cache/
+          key: warden-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            warden-cache-${{ runner.os }}-
 
       - name: Setup Ollama
         run: |
@@ -43,6 +55,10 @@ jobs:
             sleep 1
           done
           ollama pull qwen2.5-coder:3b
+          curl -s http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5-coder:3b","prompt":"","keep_alive":-1}' \
+            -o /dev/null
+          echo "✅ Model warm and ready."
 
 
       - name: Refresh Intelligence

--- a/.github/workflows/warden-pr.yml
+++ b/.github/workflows/warden-pr.yml
@@ -13,6 +13,10 @@ jobs:
       WARDEN_LLM_PROVIDER: ollama
       WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
+      OLLAMA_NUM_THREADS: "2"
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_FLASH_ATTENTION: "1"
+      OLLAMA_CONTEXT_LENGTH: "4096"
 
     steps:
       - name: Checkout Code
@@ -29,6 +33,14 @@ jobs:
       - name: Install Warden
         run: pip install "warden-core[semantic]"
 
+      - name: Cache Warden Triage & Findings
+        uses: actions/cache@v5
+        with:
+          path: .warden/cache/
+          key: warden-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            warden-cache-${{ runner.os }}-
+
       - name: Setup Ollama
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
@@ -43,6 +55,10 @@ jobs:
             sleep 1
           done
           ollama pull qwen2.5-coder:3b
+          curl -s http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5-coder:3b","prompt":"","keep_alive":-1}' \
+            -o /dev/null
+          echo "✅ Model warm and ready."
 
 
       - name: Run Warden PR Scan

--- a/.github/workflows/warden-release.yml
+++ b/.github/workflows/warden-release.yml
@@ -19,6 +19,10 @@ jobs:
       WARDEN_LLM_PROVIDER: ollama
       WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
+      OLLAMA_NUM_THREADS: "2"
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_FLASH_ATTENTION: "1"
+      OLLAMA_CONTEXT_LENGTH: "4096"
 
     steps:
       - name: Checkout Code
@@ -32,6 +36,14 @@ jobs:
 
       - name: Install Warden
         run: pip install "warden-core[semantic]"
+
+      - name: Cache Warden Triage & Findings
+        uses: actions/cache@v5
+        with:
+          path: .warden/cache/
+          key: warden-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            warden-cache-${{ runner.os }}-
 
       - name: Setup Ollama
         run: |
@@ -47,6 +59,10 @@ jobs:
             sleep 1
           done
           ollama pull qwen2.5-coder:3b
+          curl -s http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5-coder:3b","prompt":"","keep_alive":-1}' \
+            -o /dev/null
+          echo "✅ Model warm and ready."
 
 
       - name: Refresh Intelligence

--- a/src/warden/llm/providers/ollama.py
+++ b/src/warden/llm/providers/ollama.py
@@ -47,7 +47,7 @@ class OllamaClient(ILlmClient):
     def provider(self) -> LlmProvider:
         return LlmProvider.OLLAMA
 
-    @resilient(name="provider_send", timeout_seconds=120.0, retry_max_attempts=2)
+    @resilient(name="provider_send", timeout_seconds=180.0, retry_max_attempts=2)
     async def send_async(self, request: LlmRequest) -> LlmResponse:
         """
         Send a request to the local Ollama instance.


### PR DESCRIPTION
## Problem
\`provider_send timed out after 120s\` — qwen2.5-coder:3b on a 2-core GitHub runner took 60-180s per 2-file triage batch.

## Root Cause
1. No triage cache between CI runs → every file re-triaged on every run
2. Ollama default context window is 32K → massive KV cache allocation on 2GB RAM
3. No model warm-up → 15-30s cold start on first request
4. 120s timeout too tight for 3b on slow CPU

## Fix (no model change — stays on qwen2.5-coder:3b)

| Change | Expected Impact |
|--------|----------------|
| Cache `.warden/cache/` between runs | 10-100x fewer LLM calls on PRs |
| `OLLAMA_CONTEXT_LENGTH=4096` | 2-3x faster inference (triage prompts are ~2K tokens) |
| `OLLAMA_FLASH_ATTENTION=1` | Reduced KV cache memory pressure |
| `OLLAMA_NUM_THREADS=2` + `OLLAMA_MAX_LOADED_MODELS=1` | No resource thrash |
| `keep_alive=-1` warm-up | Eliminates 15-30s cold start |
| Resilient timeout 120s → 180s | Safety buffer for worst case |