### PR TITLE
perf(warden.yml): add Ollama optimizations missed in PR #250

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -21,6 +21,10 @@ jobs:
       WARDEN_LLM_PROVIDER: ollama
       WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
       OLLAMA_HOST: http://localhost:11434
+      OLLAMA_NUM_THREADS: "2"
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_FLASH_ATTENTION: "1"
+      OLLAMA_CONTEXT_LENGTH: "4096"
 
 
     steps:
@@ -36,6 +40,14 @@ jobs:
       - name: Install Warden
         run: pip install ".[semantic]"
 
+      - name: Cache Warden Triage & Findings
+        uses: actions/cache@v5
+        with:
+          path: .warden/cache/
+          key: warden-cache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            warden-cache-${{ runner.os }}-
+
       - name: Setup Ollama
         run: |
           curl -fsSL https://ollama.com/install.sh | sh
@@ -48,6 +60,10 @@ jobs:
             sleep 1
           done
           ollama pull qwen2.5-coder:3b
+          curl -s http://localhost:11434/api/generate \
+            -d '{"model":"qwen2.5-coder:3b","prompt":"","keep_alive":-1}' \
+            -o /dev/null
+          echo "✅ Model warm and ready."
 
       - name: Run Warden Scan
         run: |


### PR DESCRIPTION
warden.yml was not updated in PR #250 alongside the other workflow files. This caused continued timeout failures on push-to-main runs. Adds the same Ollama optimizations (env vars, triage cache, warm-up).