### PR TITLE
perf(triage): add Python protobuf suffixes to heuristic skip list

### DIFF
--- a/src/warden/analysis/domain/triage_heuristics.py
+++ b/src/warden/analysis/domain/triage_heuristics.py
@@ -82,7 +82,9 @@ _GENERATED_SUFFIXES: tuple[str, ...] = (
     # Dart codegen (json_serializable, freezed)
     ".g.dart",
     ".freezed.dart",
-    # Protocol Buffers (non-Python languages; Python _pb2.py already in path check)
+    # Protocol Buffers — all languages including Python
+    "_pb2.py",
+    "_pb2_grpc.py",
     "_pb.js",
     "_pb.ts",
     ".pb.go",

--- a/tests/analysis/application/test_triage_optimization.py
+++ b/tests/analysis/application/test_triage_optimization.py
@@ -96,6 +96,46 @@ class TestImprovedHeuristics:
         cf = _make_code_file(path, content="a" * 500, line_count=50)
         assert is_heuristic_safe(cf) is True
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "app/__generated__/schema.ts",
+            "lib/generated/models.dart",
+            "proto/gen/service.go",
+            "api/grpc_generated/service_pb2.py",
+        ],
+    )
+    def test_safe_codegen_directories(self, path: str) -> None:
+        cf = _make_code_file(path, content="a" * 500, line_count=50)
+        assert is_heuristic_safe(cf) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # Minified web assets
+            "static/vendor/jquery.min.js",
+            "assets/styles/app.min.css",
+            # Dart codegen
+            "lib/models/user.g.dart",
+            "lib/models/user.freezed.dart",
+            # Protocol Buffers — Python
+            "proto/service_pb2.py",
+            "proto/service_pb2_grpc.py",
+            # Protocol Buffers — other languages
+            "proto/service_pb.js",
+            "proto/service.pb.go",
+            "proto/service.pb.swift",
+            "proto/service.pb.cc",
+            # gRPC generated
+            "proto/service_grpc_pb.js",
+            # GraphQL Apollo codegen
+            "src/graphql/queries.graphql.ts",
+        ],
+    )
+    def test_safe_generated_suffixes(self, path: str) -> None:
+        cf = _make_code_file(path, content="a" * 500, line_count=50)
+        assert is_heuristic_safe(cf) is True
+
     def test_small_file_is_safe(self) -> None:
         cf = _make_code_file("src/app.py", content="x = 1", line_count=1)
         assert is_heuristic_safe(cf) is True


### PR DESCRIPTION
## Summary
- Add `_pb2.py` and `_pb2_grpc.py` to `_GENERATED_SUFFIXES` in `triage_heuristics.py` so Python protobuf generated files are caught at the heuristic layer instead of relying on the deeper `_is_generated_file()` path check
- Add test coverage for all generated-suffix patterns (minified, Dart codegen, protobuf, gRPC, GraphQL) and codegen directory segments (`__generated__/`, `generated/`, `gen/`, `grpc_generated/`)

Closes #97

## Changes
**`src/warden/analysis/domain/triage_heuristics.py`**
- Added `_pb2.py` and `_pb2_grpc.py` to `_GENERATED_SUFFIXES` tuple
- Updated comment to reflect all languages are now covered

**`tests/analysis/application/test_triage_optimization.py`**
- Added `test_safe_codegen_directories` parametrized test (4 cases)
- Added `test_safe_generated_suffixes` parametrized test (12 cases)

## Test plan
- [x] `python3 -m pytest tests/ -k "triage" -x` passes (61 passed, 4 skipped)
- [ ] Verify no regressions in full test suite
- [ ] Confirm protobuf-heavy projects skip `_pb2.py` files at heuristic level