### PR TITLE
fix(cache): auto-derive schema version from model field signatures

### DIFF
--- a/src/warden/shared/utils/schema_version.py
+++ b/src/warden/shared/utils/schema_version.py
@@ -1,0 +1,47 @@
+"""Auto-derive schema version from dataclass or Pydantic model field signatures.
+
+Used by cache modules (findings_cache, triage_cache) to detect when the
+cached model's field layout has changed and automatically invalidate stale
+entries -- removing the need for developers to bump a manual constant.
+
+The derived version is an 8-character hex digest of the model's field names
+and type annotations, so any addition, removal, or type change produces a
+different version string.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+from typing import Any
+
+
+def derive_schema_version(cls: type) -> str:
+    """Return a short hex digest that changes when *cls*'s field signature changes.
+
+    Supports both standard ``@dataclass`` classes (via ``dataclasses.fields``)
+    and Pydantic ``BaseModel`` subclasses (via ``model_fields``).
+
+    The digest is based on ``(field_name, annotation_repr)`` pairs sorted by
+    name to ensure deterministic output regardless of declaration order.
+    """
+    fields: list[tuple[str, str]] = _extract_fields(cls)
+    # Sort by name for determinism (declaration order may vary across versions)
+    fields.sort()
+    raw = str(fields).encode()
+    return hashlib.md5(raw).hexdigest()[:8]
+
+
+def _extract_fields(cls: type) -> list[tuple[str, str]]:
+    """Extract ``(name, type_repr)`` pairs from a dataclass or Pydantic model."""
+    # 1. Try standard dataclass
+    if dataclasses.is_dataclass(cls):
+        return [(f.name, str(f.type)) for f in dataclasses.fields(cls)]  # type: ignore[arg-type]
+
+    # 2. Try Pydantic BaseModel (v2 API)
+    model_fields: dict[str, Any] | None = getattr(cls, "model_fields", None)
+    if model_fields is not None:
+        return [(name, str(info.annotation)) for name, info in model_fields.items()]
+
+    msg = f"{cls.__name__} is neither a dataclass nor a Pydantic BaseModel"
+    raise TypeError(msg)

--- a/tests/analysis/application/test_triage_optimization.py
+++ b/tests/analysis/application/test_triage_optimization.py
@@ -1,9 +1,10 @@
 """Tests for 4-layer triage optimization.
 
 Covers:
-- TestTriageBypass:          Codex/Claude Code → heuristic-only, Groq/Ollama → LLM triage
+- TestTriageBypass:          Codex/Claude Code -> heuristic-only, Groq/Ollama -> LLM triage
 - TestImprovedHeuristics:    Extended safe-file detection
 - TestTriageCache:           Miss / hit / invalidation / disk persistence / eviction / corruption
+- TestTriageCacheSchema:     Auto-derived schema version / mismatch eviction
 - TestAdaptiveBatchSizing:   Provider-aware batch sizes
 """
 
@@ -16,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from warden.analysis.application.triage_cache import TriageCacheManager
+from warden.analysis.application.triage_cache import TRIAGE_CACHE_SCHEMA_VERSION, TriageCacheManager
 from warden.analysis.application.triage_service import TriageService
 from warden.analysis.domain.triage_heuristics import is_heuristic_safe
 from warden.analysis.domain.triage_models import RiskScore, TriageDecision, TriageLane
@@ -195,7 +196,7 @@ class TestTriageCache:
         decision = self._make_decision()
         cache.put("src/a.py", "content_v1", decision)
 
-        # Different content → miss
+        # Different content -> miss
         assert cache.get("src/a.py", "content_v2") is None
 
     def test_disk_persistence(self, tmp_path: Path) -> None:
@@ -238,6 +239,83 @@ class TestTriageCache:
         k1 = TriageCacheManager.cache_key("src/a.py", "hello world")
         k2 = TriageCacheManager.cache_key("src/a.py", "goodbye world")
         assert k1 != k2
+
+
+# ===========================================================================
+# STEP 3b: Triage Cache Schema Versioning
+# ===========================================================================
+
+
+class TestTriageCacheSchema:
+    """Auto-derived schema version and mismatch eviction for triage cache."""
+
+    def _make_cache(self, tmp_path: Path) -> TriageCacheManager:
+        return TriageCacheManager(tmp_path, max_entries=10)
+
+    def _make_decision(self, path: str = "src/a.py") -> TriageDecision:
+        return TriageDecision(
+            file_path=path,
+            lane=TriageLane.MIDDLE,
+            risk_score=RiskScore(score=5.0, confidence=0.8, reasoning="test", category="logic"),
+            processing_time_ms=10.0,
+        )
+
+    def test_schema_version_is_auto_derived_string(self) -> None:
+        """TRIAGE_CACHE_SCHEMA_VERSION should be a hex string, not a manual int."""
+        assert isinstance(TRIAGE_CACHE_SCHEMA_VERSION, str)
+        assert len(TRIAGE_CACHE_SCHEMA_VERSION) == 8
+        # Must be valid hex
+        int(TRIAGE_CACHE_SCHEMA_VERSION, 16)
+
+    def test_schema_version_is_deterministic(self) -> None:
+        """Calling derive_schema_version twice yields the same result."""
+        from warden.shared.utils.schema_version import derive_schema_version
+
+        v1 = derive_schema_version(TriageDecision)
+        v2 = derive_schema_version(TriageDecision)
+        assert v1 == v2
+        assert v1 == TRIAGE_CACHE_SCHEMA_VERSION
+
+    def test_correct_schema_version_hits(self, tmp_path: Path) -> None:
+        cache = self._make_cache(tmp_path)
+        cache.put("src/a.py", "content_v1", self._make_decision())
+
+        result = cache.get("src/a.py", "content_v1")
+        assert result is not None
+        assert result.lane == TriageLane.MIDDLE
+
+    def test_schema_version_mismatch_evicts_entry(self, tmp_path: Path) -> None:
+        """Manually inject a stale schema version; get should return None and delete entry."""
+        cache = self._make_cache(tmp_path)
+        content = "some content"
+
+        cache.put("src/a.py", content, self._make_decision())
+        key = TriageCacheManager.cache_key("src/a.py", content)
+
+        # Corrupt the schema version in internal store
+        cache._store[key]["_schema_v"] = "stale000"
+
+        result = cache.get("src/a.py", content)
+        assert result is None
+
+        # Entry must have been evicted from store
+        assert key not in cache._store
+
+    def test_schema_mismatch_on_disk_reload(self, tmp_path: Path) -> None:
+        """Entries with wrong schema version should be evicted after flush+reload."""
+        cache1 = self._make_cache(tmp_path)
+        cache1.put("src/a.py", "content_v1", self._make_decision())
+
+        # Corrupt the schema version before flushing
+        key = TriageCacheManager.cache_key("src/a.py", "content_v1")
+        cache1._store[key]["_schema_v"] = "oldver00"
+        cache1._dirty = True
+        cache1.flush()
+
+        # New instance loads from disk, entry should be evicted on get
+        cache2 = self._make_cache(tmp_path)
+        result = cache2.get("src/a.py", "content_v1")
+        assert result is None
 
 
 # ===========================================================================
@@ -289,7 +367,7 @@ class TestAdaptiveBatchSizing:
         wrapper.fast_clients = [fast]            # fast tier has Ollama
 
         svc = TriageService(wrapper)
-        # Must pick Ollama (5), not Groq (15) — triage uses fast tier
+        # Must pick Ollama (5), not Groq (15) -- triage uses fast tier
         assert svc._requested_batch_size == 5
 
     def test_orchestrated_client_no_fast_tier_falls_to_smart(self) -> None:
@@ -380,11 +458,11 @@ class TestTriageBypass:
         decisions = context.triage_decisions
         assert len(decisions) == 2
 
-        # __init__.py → FAST
+        # __init__.py -> FAST
         init_decision = decisions["src/__init__.py"]
         assert init_decision["lane"] == TriageLane.FAST
 
-        # auth.py → MIDDLE
+        # auth.py -> MIDDLE
         auth_decision = decisions["src/auth.py"]
         assert auth_decision["lane"] == TriageLane.MIDDLE
 

--- a/tests/shared/utils/test_schema_version.py
+++ b/tests/shared/utils/test_schema_version.py
@@ -1,0 +1,126 @@
+"""Tests for derive_schema_version utility."""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel, Field
+
+from warden.shared.utils.schema_version import derive_schema_version
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: simple dataclass and Pydantic model families
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SampleDC:
+    name: str
+    value: int
+    flag: bool = False
+
+
+@dataclass
+class _SampleDCExtra:
+    """Same as _SampleDC but with an extra field."""
+
+    name: str
+    value: int
+    flag: bool = False
+    extra: str = ""
+
+
+@dataclass
+class _SampleDCRetyped:
+    """Same field names as _SampleDC but 'value' changed from int to str."""
+
+    name: str
+    value: str
+    flag: bool = False
+
+
+class _SamplePydantic(BaseModel):
+    name: str
+    score: float = Field(default=0.0)
+
+
+class _SamplePydanticExtra(BaseModel):
+    name: str
+    score: float = Field(default=0.0)
+    tag: str = ""
+
+
+class _SamplePydanticRetyped(BaseModel):
+    name: str
+    score: int = Field(default=0)
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestDeriveSchemaVersion:
+    """derive_schema_version produces stable, distinct digests."""
+
+    def test_deterministic_for_dataclass(self) -> None:
+        v1 = derive_schema_version(_SampleDC)
+        v2 = derive_schema_version(_SampleDC)
+        assert v1 == v2
+
+    def test_deterministic_for_pydantic(self) -> None:
+        v1 = derive_schema_version(_SamplePydantic)
+        v2 = derive_schema_version(_SamplePydantic)
+        assert v1 == v2
+
+    def test_returns_8_char_hex(self) -> None:
+        v = derive_schema_version(_SampleDC)
+        assert isinstance(v, str)
+        assert len(v) == 8
+        int(v, 16)  # must be valid hex
+
+    def test_adding_field_changes_version_dataclass(self) -> None:
+        v_base = derive_schema_version(_SampleDC)
+        v_extra = derive_schema_version(_SampleDCExtra)
+        assert v_base != v_extra
+
+    def test_changing_type_changes_version_dataclass(self) -> None:
+        v_base = derive_schema_version(_SampleDC)
+        v_retyped = derive_schema_version(_SampleDCRetyped)
+        assert v_base != v_retyped
+
+    def test_adding_field_changes_version_pydantic(self) -> None:
+        v_base = derive_schema_version(_SamplePydantic)
+        v_extra = derive_schema_version(_SamplePydanticExtra)
+        assert v_base != v_extra
+
+    def test_changing_type_changes_version_pydantic(self) -> None:
+        v_base = derive_schema_version(_SamplePydantic)
+        v_retyped = derive_schema_version(_SamplePydanticRetyped)
+        assert v_base != v_retyped
+
+    def test_raises_for_plain_class(self) -> None:
+        class _PlainClass:
+            x: int = 0
+
+        with pytest.raises(TypeError, match="neither a dataclass nor a Pydantic BaseModel"):
+            derive_schema_version(_PlainClass)
+
+    def test_works_with_real_finding(self) -> None:
+        """Sanity check: derives a version from the actual Finding dataclass."""
+        from warden.validation.domain.frame import Finding
+
+        v = derive_schema_version(Finding)
+        assert isinstance(v, str)
+        assert len(v) == 8
+
+    def test_works_with_real_triage_decision(self) -> None:
+        """Sanity check: derives a version from the actual TriageDecision model."""
+        from warden.analysis.domain.triage_models import TriageDecision
+
+        v = derive_schema_version(TriageDecision)
+        assert isinstance(v, str)
+        assert len(v) == 8


### PR DESCRIPTION
## Summary

- **Closes #136** — `findings_cache` `CACHE_SCHEMA_VERSION` was a manual constant (`= 1`). Replaced with auto-derived hex digest from `Finding` dataclass field signatures.
- **Closes #143** — `triage_cache` had no schema versioning at all. Added `TRIAGE_CACHE_SCHEMA_VERSION` auto-derived from `TriageDecision` Pydantic model fields, with validation on cache load and eviction on mismatch.
- Added shared utility `warden.shared.utils.schema_version.derive_schema_version()` that supports both `@dataclass` and Pydantic `BaseModel` subclasses.

## Changes

| File | What changed |
|------|-------------|
| `src/warden/shared/utils/schema_version.py` | New shared utility — derives 8-char hex digest from model field `(name, type)` pairs |
| `src/warden/pipeline/application/orchestrator/findings_cache.py` | `CACHE_SCHEMA_VERSION` changed from `int(1)` to `str(derive_schema_version(Finding))` |
| `src/warden/analysis/application/triage_cache.py` | Added `TRIAGE_CACHE_SCHEMA_VERSION`, `_schema_v` written on `put()`, validated on `get()` with eviction on mismatch |
| `tests/shared/utils/test_schema_version.py` | New — covers determinism, field addition/type change detection, both dataclass and Pydantic, error on plain class |
| `tests/pipeline/application/orchestrator/test_findings_cache.py` | Updated schema mismatch test for string-based version; added auto-derive validation tests |
| `tests/analysis/application/test_triage_optimization.py` | Added `TestTriageCacheSchema` class — version type, determinism, hit, mismatch eviction, disk reload mismatch |

## Test plan

- [x] `python -m pytest tests/ -k "cache or schema_version" -x` — 84 passed, 4 skipped
- [ ] Verify existing findings_cache entries are auto-invalidated after upgrade (schema version changes from int `1` to hex string)
- [ ] Verify triage_cache entries without `_schema_v` field are evicted on first read after upgrade