### PR TITLE
fix(llm): ensure LlmResponse.model and .provider are always populated

### DIFF
--- a/src/warden/llm/providers/anthropic.py
+++ b/src/warden/llm/providers/anthropic.py
@@ -105,7 +105,7 @@ class AnthropicClient(ILlmClient):
                 content=result["content"][0]["text"],
                 success=True,
                 provider=self.provider,
-                model=result.get("model"),
+                model=result.get("model") or request.model or self._default_model,
                 prompt_tokens=usage.get("input_tokens"),
                 completion_tokens=usage.get("output_tokens"),
                 total_tokens=usage.get("input_tokens", 0) + usage.get("output_tokens", 0),

--- a/src/warden/llm/providers/deepseek.py
+++ b/src/warden/llm/providers/deepseek.py
@@ -76,7 +76,7 @@ class DeepSeekClient(ILlmClient):
                 content=result["choices"][0]["message"]["content"],
                 success=True,
                 provider=self.provider,
-                model=result.get("model"),
+                model=result.get("model") or request.model or self._default_model,
                 prompt_tokens=usage.get("prompt_tokens"),
                 completion_tokens=usage.get("completion_tokens"),
                 total_tokens=usage.get("total_tokens"),

--- a/src/warden/llm/providers/groq.py
+++ b/src/warden/llm/providers/groq.py
@@ -151,7 +151,7 @@ class GroqClient(ILlmClient):
                 content=result["choices"][0]["message"]["content"],
                 success=True,
                 provider=self.provider,
-                model=result.get("model"),
+                model=result.get("model") or model,
                 prompt_tokens=usage.get("prompt_tokens"),
                 completion_tokens=usage.get("completion_tokens"),
                 total_tokens=usage.get("total_tokens"),

--- a/src/warden/llm/providers/openai.py
+++ b/src/warden/llm/providers/openai.py
@@ -113,7 +113,7 @@ class OpenAIClient(ILlmClient):
                 content=result["choices"][0]["message"]["content"],
                 success=True,
                 provider=self.provider,
-                model=result.get("model"),
+                model=result.get("model") or request.model or self._default_model,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=total_tokens,


### PR DESCRIPTION
## Summary
- **Fixes #146**: `LlmResponse.model` and `.provider` were `Optional` and some providers did not always populate them, causing findings to lack LLM model attribution.
- Added fallback chains at the provider level (Anthropic, OpenAI, DeepSeek, Groq) so `model` is always set from `result.get("model") or request.model or self._default_model`.
- Added `_ensure_attribution()` defense-in-depth in `OrchestratedLlmClient` that fills in model/provider gaps at every response return point (smart tier, fast tier race winner, smart-to-fast fallback).

## Changes
| File | Change |
|------|--------|
| `src/warden/llm/providers/anthropic.py` | Add model fallback: `result.get("model") or request.model or self._default_model` |
| `src/warden/llm/providers/openai.py` | Add model fallback: `result.get("model") or request.model or self._default_model` |
| `src/warden/llm/providers/deepseek.py` | Add model fallback: `result.get("model") or request.model or self._default_model` |
| `src/warden/llm/providers/groq.py` | Add model fallback: `result.get("model") or model` (uses sanitized local var) |
| `src/warden/llm/providers/orchestrated.py` | Add `_ensure_attribution()` static method; wrap all 3 return paths |
| `tests/llm/providers/test_orchestrated.py` | Add `TestResponseAttribution` class with 8 new tests |

## Test plan
- [x] All 41 provider tests pass (`tests/llm/providers/`)
- [x] All 166 LLM unit tests pass (excluding pre-existing failures)
- [x] New `TestResponseAttribution` covers: fallback model, fallback provider, preserve existing, smart-to-fast fallback, request model precedence, static method unit tests, None-safe fallbacks