### PR TITLE
fix(classification): persist suppression_rules in classification cache

### DIFF
--- a/src/warden/pipeline/application/executors/classification_executor.py
+++ b/src/warden/pipeline/application/executors/classification_executor.py
@@ -143,16 +143,16 @@ class ClassificationExecutor(BasePhaseExecutor):
 
                     # -- Layer 1: classification cache --
                     cache_key = ClassificationCache.make_key(files_to_classify, available_ids, self.project_root)
-                    cached_frames = self._classification_cache.get(cache_key)
-                    if cached_frames is not None:
+                    cached = self._classification_cache.get(cache_key)
+                    if cached is not None:
                         logger.info(
                             "classification_cache_hit",
-                            frames=cached_frames,
+                            frames=cached["frames"],
                             skipped_llm=True,
                         )
                         result = ClassificationResult(
-                            selected_frames=cached_frames,
-                            suppression_rules=[],
+                            selected_frames=cached["frames"],
+                            suppression_rules=cached["suppression_rules"],
                             reasoning="Classification from cache (unchanged inputs)",
                         )
                     else:
@@ -196,7 +196,11 @@ class ClassificationExecutor(BasePhaseExecutor):
 
                         # Store in cache regardless of whether LLM was used
                         if result and result.selected_frames:
-                            self._classification_cache.put(cache_key, result.selected_frames)
+                            self._classification_cache.put(
+                                cache_key,
+                                result.selected_frames,
+                                result.suppression_rules,
+                            )
                             logger.debug("classification_cached", frames=result.selected_frames)
 
                 # Validate result exists (should always be set by above branches)


### PR DESCRIPTION
## Summary

Closes #113

- **Bug**: `ClassificationCache` persisted selected frame IDs but never saved `suppression_rules`. On cache hit, `context.suppression_rules` was always set to `[]`, silently discarding suppression decisions from previous scans.
- **Fix**: Added `suppression_rules` to the cache value format in both `put()` and `get()` methods. Updated `ClassificationExecutor` to restore suppression rules from cache on hit and to pass them when storing results.
- Legacy cache entries that lack the `suppression_rules` field are handled gracefully by defaulting to an empty list.

## Affected Files

- `src/warden/pipeline/application/executors/classification_cache.py` -- `get()` now returns a dict with both `frames` and `suppression_rules`; `put()` accepts an optional `suppression_rules` parameter
- `src/warden/pipeline/application/executors/classification_executor.py` -- cache hit path restores `suppression_rules`; cache put call forwards `result.suppression_rules`

## Test plan

- [x] All 33 classification-related tests pass (`pytest -k "classif"`)
- [ ] Verify suppression rules survive a cache round-trip in an integration scan
- [ ] Confirm legacy cache files (without `suppression_rules` key) do not cause errors