### PR TITLE
refactor: unify docstring/comment FP detection logic (#66)

### DIFF
--- a/src/warden/cleaning/application/analyzers/documentation_analyzer.py
+++ b/src/warden/cleaning/application/analyzers/documentation_analyzer.py
@@ -23,6 +23,7 @@ from warden.cleaning.domain.models import (
     CleaningResult,
     CleaningSuggestion,
 )
+from warden.shared.utils.docstring_utils import has_param_section, has_return_section
 from warden.validation.domain.frame import CodeFile
 
 logger = structlog.get_logger()
@@ -290,13 +291,8 @@ class DocumentationAnalyzer(BaseCleaningAnalyzer):
                     if isinstance(node, ast.FunctionDef) and node.args.args:
                         params = [arg.arg for arg in node.args.args if arg.arg != "self"]
                         if params:
-                            # Check if parameters are documented (simple heuristic)
-                            has_params_section = any(
-                                keyword in docstring.lower()
-                                for keyword in ["args:", "arguments:", "parameters:", "params:"]
-                            )
-
-                            if not has_params_section:
+                            # Check if parameters are documented (shared utility)
+                            if not has_param_section(docstring):
                                 issues.append(
                                     CleaningIssue(
                                         issue_type=CleaningIssueType.POOR_DOC,
@@ -306,13 +302,9 @@ class DocumentationAnalyzer(BaseCleaningAnalyzer):
                                     )
                                 )
 
-                            # Check for return documentation if not None
+                            # Check for return documentation if not None (shared utility)
                             if not self._returns_none(node):
-                                has_return_doc = any(
-                                    keyword in docstring.lower()
-                                    for keyword in ["returns:", "return:", "yields:", "yield:"]
-                                )
-                                if not has_return_doc:
+                                if not has_return_section(docstring):
                                     issues.append(
                                         CleaningIssue(
                                             issue_type=CleaningIssueType.POOR_DOC,

--- a/src/warden/shared/utils/docstring_utils.py
+++ b/src/warden/shared/utils/docstring_utils.py
@@ -1,0 +1,122 @@
+"""
+Shared Docstring/Comment Detection Utilities
+
+Centralised keyword sets and helper functions for detecting docstring sections,
+comment markers, and documentation patterns.  Used by both the false-positive
+heuristic filter (FindingVerificationService) and the documentation quality
+analyser (DocumentationAnalyzer) so that keyword lists stay in sync.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Canonical keyword / marker sets
+# ---------------------------------------------------------------------------
+
+# Google / Sphinx / NumPy-style section headers found inside docstrings.
+# These are stored in *lower-case*; callers should normalise before lookup.
+DOCSTRING_SECTION_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "args:",
+        "arguments:",
+        "parameters:",
+        "params:",
+        "returns:",
+        "return:",
+        "yields:",
+        "yield:",
+        "raises:",
+        "example:",
+        "examples:",
+        "note:",
+        "notes:",
+        "warning:",
+        "warnings:",
+        "see also:",
+        "references:",
+        "attributes:",
+        "todo:",
+    }
+)
+
+# Subset: keywords that document *parameters* specifically.
+DOCSTRING_PARAM_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "args:",
+        "arguments:",
+        "parameters:",
+        "params:",
+    }
+)
+
+# Subset: keywords that document *return / yield values* specifically.
+DOCSTRING_RETURN_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "returns:",
+        "return:",
+        "yields:",
+        "yield:",
+    }
+)
+
+# Markers that indicate the *code snippet itself* is a comment or docstring
+# (used by the FP heuristic filter to short-circuit verification).
+COMMENT_START_MARKERS: tuple[str, ...] = (
+    "#",
+    "//",
+    "/*",
+    '"""',
+    "'''",
+)
+
+# Additional indicators that a code snippet lives inside documentation
+# context (e.g. a docstring body or inline example comment).
+DOCSTRING_CONTEXT_INDICATORS: tuple[str, ...] = (
+    '"""',
+    "'''",
+    "# Example",
+    "# Usage",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def has_docstring_section_keyword(text: str) -> bool:
+    """Return True if *text* contains any recognised docstring section keyword.
+
+    The check is case-insensitive and looks for keywords anywhere in the text.
+    """
+    text_lower = text.lower()
+    return any(kw in text_lower for kw in DOCSTRING_SECTION_KEYWORDS)
+
+
+def has_param_section(docstring: str) -> bool:
+    """Return True if *docstring* contains a parameter documentation section."""
+    docstring_lower = docstring.lower()
+    return any(kw in docstring_lower for kw in DOCSTRING_PARAM_KEYWORDS)
+
+
+def has_return_section(docstring: str) -> bool:
+    """Return True if *docstring* contains a return/yield documentation section."""
+    docstring_lower = docstring.lower()
+    return any(kw in docstring_lower for kw in DOCSTRING_RETURN_KEYWORDS)
+
+
+def looks_like_comment_or_docstring(code: str) -> bool:
+    """Return True if *code* starts with a comment or docstring marker."""
+    stripped = code.lstrip()
+    return stripped.startswith(COMMENT_START_MARKERS)
+
+
+def has_docstring_context_indicator(code: str) -> bool:
+    """Return True if *code* contains indicators of documentation context.
+
+    This combines the section keyword check with additional markers like
+    triple-quote strings and inline example comments.
+    """
+    if has_docstring_section_keyword(code):
+        return True
+    return any(indicator in code for indicator in DOCSTRING_CONTEXT_INDICATORS)


### PR DESCRIPTION
## Summary

- Extracted shared docstring keyword sets and detection helpers into a new `src/warden/shared/utils/docstring_utils.py` module
- Refactored `FindingVerificationService._is_obvious_false_positive` to use `looks_like_comment_or_docstring()` and `has_docstring_context_indicator()` instead of inline keyword lists
- Refactored `DocumentationAnalyzer._check_docstring_quality` to use `has_param_section()` and `has_return_section()` instead of inline keyword checks

Closes #66

## Test plan

- [x] All existing tests pass: `python -m pytest tests/ -k "verif or docstr or documentation" -x` (33 passed)
- [x] Verified shared module imports and assertions with smoke test
- [ ] Confirm no regression in full CI pipeline