### PR TITLE
fix(output): surface remediation.code in SARIF and CLI output

### DIFF
--- a/src/warden/cli/commands/scan.py
+++ b/src/warden/cli/commands/scan.py
@@ -1167,6 +1167,26 @@ def _render_text_report(
                 )
                 console.print(Padding(syntax, (0, 0, 0, 4)))
 
+            # ── Suggested fix (from Fortification remediation) ── (#197)
+            rem = finding.get("remediation")
+            rem_code = ""
+            if isinstance(rem, dict):
+                rem_code = rem.get("code", "")
+            elif rem is not None:
+                rem_code = getattr(rem, "code", "")
+            if rem_code:
+                console.print("    [bold green]Suggested Fix:[/bold green]")
+                fix_syntax = Syntax(
+                    rem_code,
+                    lang,
+                    theme="github-dark",
+                    line_numbers=False,
+                    word_wrap=True,
+                    background_color="default",
+                    indent_guides=False,
+                )
+                console.print(Padding(fix_syntax, (0, 0, 0, 4)))
+
             # ── Remediation tip (first meaningful line) ──
             if detail:
                 tip_lines = [

--- a/src/warden/pipeline/application/orchestrator/rule_executor.py
+++ b/src/warden/pipeline/application/orchestrator/rule_executor.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from warden.rules.application.rule_validator import CustomRuleValidator
 from warden.rules.domain.models import CustomRule, CustomRuleViolation
 from warden.shared.infrastructure.logging import get_logger
-from warden.validation.domain.frame import CodeFile, Finding, Remediation
+from warden.validation.domain.frame import CodeFile, Finding
 
 logger = get_logger(__name__)
 
@@ -113,5 +113,5 @@ class RuleExecutor:
             code=violation.code_snippet,
             line=violation.line,
             is_blocker=violation.is_blocker,
-            remediation=Remediation(description=violation.suggestion, code="") if violation.suggestion else None,
+            remediation=None,  # Populated by Fortification phase when replacement code is available
         )

--- a/src/warden/reports/generator.py
+++ b/src/warden/reports/generator.py
@@ -472,6 +472,25 @@ class ReportGenerator:
                         result["properties"] = {}
                     result["properties"]["exploitEvidence"] = exploit_evidence
 
+                # Add SARIF fixes array when remediation is populated (#197)
+                remediation = self._get_val(finding, "remediation", None)
+                if remediation:
+                    rem_code = self._get_val(remediation, "code", "")
+                    rem_description = self._get_val(remediation, "description", "")
+                    if rem_code and file_path:
+                        result["fixes"] = [{
+                            "description": {"text": rem_description},
+                            "artifactChanges": [{
+                                "artifactLocation": {"uri": self._to_relative_uri(file_path)},
+                                "replacements": [{
+                                    "deletedRegion": {
+                                        "startLine": max(1, self._get_val(finding, "line", 1)),
+                                    },
+                                    "insertedContent": {"text": rem_code},
+                                }]
+                            }]
+                        }]
+
                 run["results"].append(result)
 
         # Include suppressed findings in SARIF with suppressions array (SARIF 2.1.0 §3.35) (#125).

--- a/src/warden/validation/frames/antipattern/antipattern_frame.py
+++ b/src/warden/validation/frames/antipattern/antipattern_frame.py
@@ -43,7 +43,6 @@ from warden.validation.domain.frame import (
     CodeFile,
     Finding,
     FrameResult,
-    Remediation,
     ValidationFrame,
 )
 
@@ -361,9 +360,12 @@ class AntiPatternFrame(ValidationFrame):
         for v in violations:
             location = f"{Path(v.file_path).name}:{v.line}"
 
+            # Remediation is populated by the Fortification phase when actual
+            # replacement code is available.  At detection time we only have a
+            # textual suggestion which lives in `detail`; creating a Remediation
+            # with an empty `code` would be silently dropped by downstream
+            # consumers (SARIF, CLI) so we skip it here.
             remediation = None
-            if v.suggestion:
-                remediation = Remediation(description=v.suggestion, code="")
 
             finding = Finding(
                 id=v.pattern_id,

--- a/tests/reports/test_sarif_remediation.py
+++ b/tests/reports/test_sarif_remediation.py
@@ -1,0 +1,181 @@
+"""
+Tests for SARIF remediation fixes output (#197).
+
+Validates that findings with remediation data produce correct SARIF fixes
+entries, and findings without remediation are unaffected.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from warden.reports.generator import ReportGenerator
+
+
+class TestSarifRemediationFixes:
+    """Test SARIF fixes array generation from remediation data."""
+
+    def _make_scan_results(self, findings: list[dict]) -> dict:
+        """Helper to wrap findings in a scan_results structure."""
+        return {
+            "frame_results": [
+                {
+                    "frame_id": "test-frame",
+                    "frame_name": "Test Frame",
+                    "findings": findings,
+                }
+            ]
+        }
+
+    def test_finding_with_remediation_produces_fixes(self):
+        """A finding with remediation.code should emit a SARIF fixes array."""
+        findings = [
+            {
+                "id": "sql-injection",
+                "severity": "critical",
+                "message": "SQL injection vulnerability",
+                "location": "app.py:42",
+                "line": 42,
+                "column": 1,
+                "remediation": {
+                    "description": "Use parameterized queries",
+                    "code": "cursor.execute('SELECT * FROM users WHERE id = ?', (user_id,))",
+                },
+            }
+        ]
+        scan_results = self._make_scan_results(findings)
+
+        with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as f:
+            out_path = Path(f.name)
+
+        try:
+            gen = ReportGenerator()
+            gen.generate_sarif_report(scan_results, out_path)
+
+            sarif = json.loads(out_path.read_text())
+            results = sarif["runs"][0]["results"]
+            assert len(results) >= 1
+
+            result = results[0]
+            assert "fixes" in result
+            fixes = result["fixes"]
+            assert len(fixes) == 1
+
+            fix = fixes[0]
+            assert fix["description"]["text"] == "Use parameterized queries"
+
+            changes = fix["artifactChanges"]
+            assert len(changes) == 1
+            assert changes[0]["artifactLocation"]["uri"] == "app.py"
+
+            replacements = changes[0]["replacements"]
+            assert len(replacements) == 1
+            assert replacements[0]["deletedRegion"]["startLine"] == 42
+            assert (
+                replacements[0]["insertedContent"]["text"]
+                == "cursor.execute('SELECT * FROM users WHERE id = ?', (user_id,))"
+            )
+        finally:
+            out_path.unlink(missing_ok=True)
+
+    def test_finding_without_remediation_has_no_fixes(self):
+        """A finding with no remediation should not have a fixes key."""
+        findings = [
+            {
+                "id": "todo-fixme",
+                "severity": "low",
+                "message": "TODO comment found",
+                "location": "utils.py:10",
+                "line": 10,
+                "column": 1,
+            }
+        ]
+        scan_results = self._make_scan_results(findings)
+
+        with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as f:
+            out_path = Path(f.name)
+
+        try:
+            gen = ReportGenerator()
+            gen.generate_sarif_report(scan_results, out_path)
+
+            sarif = json.loads(out_path.read_text())
+            results = sarif["runs"][0]["results"]
+            assert len(results) >= 1
+
+            result = results[0]
+            assert "fixes" not in result
+        finally:
+            out_path.unlink(missing_ok=True)
+
+    def test_finding_with_empty_remediation_code_has_no_fixes(self):
+        """A finding with remediation but empty code should not have fixes."""
+        findings = [
+            {
+                "id": "empty-catch",
+                "severity": "high",
+                "message": "Empty catch block",
+                "location": "handler.py:20",
+                "line": 20,
+                "column": 1,
+                "remediation": {
+                    "description": "Log the error or handle it properly",
+                    "code": "",
+                },
+            }
+        ]
+        scan_results = self._make_scan_results(findings)
+
+        with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as f:
+            out_path = Path(f.name)
+
+        try:
+            gen = ReportGenerator()
+            gen.generate_sarif_report(scan_results, out_path)
+
+            sarif = json.loads(out_path.read_text())
+            results = sarif["runs"][0]["results"]
+            assert len(results) >= 1
+
+            result = results[0]
+            assert "fixes" not in result
+        finally:
+            out_path.unlink(missing_ok=True)
+
+    def test_finding_with_unified_diff_in_remediation(self):
+        """Remediation with unified_diff should still emit fixes from code."""
+        findings = [
+            {
+                "id": "xss-reflected",
+                "severity": "critical",
+                "message": "Reflected XSS",
+                "location": "views.py:55",
+                "line": 55,
+                "column": 8,
+                "remediation": {
+                    "description": "Escape HTML output",
+                    "code": "from html import escape\noutput = escape(user_input)",
+                    "unified_diff": "--- original\n+++ fixed\n@@ -1 +1,2 @@\n-output = user_input\n+from html import escape\n+output = escape(user_input)",
+                },
+            }
+        ]
+        scan_results = self._make_scan_results(findings)
+
+        with tempfile.NamedTemporaryFile(suffix=".sarif", delete=False) as f:
+            out_path = Path(f.name)
+
+        try:
+            gen = ReportGenerator()
+            gen.generate_sarif_report(scan_results, out_path)
+
+            sarif = json.loads(out_path.read_text())
+            result = sarif["runs"][0]["results"][0]
+
+            assert "fixes" in result
+            assert result["fixes"][0]["artifactChanges"][0]["replacements"][0][
+                "insertedContent"
+            ]["text"] == "from html import escape\noutput = escape(user_input)"
+        finally:
+            out_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

Closes #197

- **SARIF output** (`reports/generator.py`): When a finding carries `remediation.code` (populated by the Fortification phase), a SARIF `fixes` array is now emitted on the result object. This enables GitHub Code Scanning to display suggested replacements inline.
- **CLI output** (`cli/commands/scan.py`): After each finding's code snippet, a syntax-highlighted "Suggested Fix" block is rendered when `remediation.code` is non-empty.
- **AntiPatternFrame / RuleExecutor cleanup**: Removed the `Remediation(code="")` stubs that created empty remediation objects. These were silently dropped by the new output guards and served no purpose. Remediation is now only populated by the Fortification phase when actual replacement code is available.

## Files Changed

| File | Change |
|------|--------|
| `src/warden/reports/generator.py` | Add `fixes` array to SARIF results when remediation is present |
| `src/warden/cli/commands/scan.py` | Render suggested fix block in CLI terminal output |
| `src/warden/validation/frames/antipattern/antipattern_frame.py` | Remove empty `code=""` stub, clean up unused `Remediation` import |
| `src/warden/pipeline/application/orchestrator/rule_executor.py` | Remove empty `code=""` stub, clean up unused `Remediation` import |
| `tests/reports/test_sarif_remediation.py` | New: 4 tests covering SARIF fixes generation |

## Test plan

- [x] `pytest tests/reports/test_sarif_remediation.py` -- 4 new tests pass (remediation with code, without remediation, empty code, unified diff)
- [x] `pytest tests/ -k "(report or sarif or generator or fortif)"` -- 64 passed, 4 skipped
- [x] `pytest tests/ -k "antipattern"` -- 11 passed, 4 skipped
- [ ] Manual: run `warden scan` on a project with known vulnerabilities and verify Suggested Fix blocks appear in terminal
- [ ] Manual: inspect generated `.sarif` file and confirm `fixes` array is present on findings with remediation