### PR TITLE
fix(frame_runner): inject CodeGraph/GapReport into frames via CodeGraphAware mixin

### DIFF
--- a/src/warden/pipeline/application/orchestrator/frame_runner.py
+++ b/src/warden/pipeline/application/orchestrator/frame_runner.py
@@ -22,6 +22,7 @@ from warden.validation.domain.frame import FrameResult as CodeFrameResult
 from warden.validation.domain.mixins import (
     BatchExecutable,
     Cleanable,
+    CodeGraphAware,
     DataFlowAware,
     LSPAware,
     ProjectContextAware,
@@ -389,6 +390,23 @@ class FrameRunner:
                 except Exception as e:
                     logger.error(
                         "lsp_injection_failed",
+                        frame_id=frame.frame_id,
+                        error=str(e),
+                    )
+
+        # Inject CodeGraph and GapReport into CodeGraphAware frames
+        if isinstance(frame, CodeGraphAware):
+            if hasattr(context, "code_graph") and context.code_graph is not None:
+                try:
+                    frame.set_code_graph(context.code_graph, getattr(context, "gap_report", None))
+                    logger.debug(
+                        "code_graph_injected",
+                        frame_id=frame.frame_id,
+                        has_gap_report=context.gap_report is not None,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "code_graph_injection_failed",
                         frame_id=frame.frame_id,
                         error=str(e),
                     )

--- a/src/warden/validation/domain/mixins.py
+++ b/src/warden/validation/domain/mixins.py
@@ -167,3 +167,34 @@ class DataFlowAware(ABC):
                  init_fields populated by DataDependencyService.
         """
         raise NotImplementedError
+
+
+class CodeGraphAware(ABC):
+    """
+    Mixin for frames that consume CodeGraph and GapReport data.
+
+    Frames implementing this mixin receive the pre-computed CodeGraph
+    (module dependency graph) and its associated GapReport (coverage gaps,
+    broken imports, circular dependencies) from Phase 0.7 (PRE-ANALYSIS).
+    The pipeline's ``FrameRunner`` calls ``set_code_graph`` before frame
+    execution.
+
+    Example:
+        class MyFrame(ValidationFrame, CodeGraphAware):
+            def set_code_graph(self, code_graph, gap_report):
+                self._code_graph = code_graph
+                self._gap_report = gap_report
+    """
+
+    @abstractmethod
+    def set_code_graph(self, code_graph: Any, gap_report: Any) -> None:
+        """
+        Inject CodeGraph and GapReport for structural analysis.
+
+        Args:
+            code_graph: CodeGraph instance with module nodes and edges
+                        representing the project's import/dependency structure.
+            gap_report: GapReport instance with coverage metrics, broken
+                        imports, circular dependencies, and orphan files.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- **Fixes #109**: `context.code_graph` and `context.gap_report` produced in Phase 0.7 were never injected into frames by `FrameRunner`, breaking the intelligence chain for architecture and security analysis.
- Adds `CodeGraphAware` ABC mixin (parallel to existing `TaintAware`, `LSPAware`, `DataFlowAware`) with `set_code_graph(code_graph, gap_report)` contract.
- Wires the injection in `FrameRunner._execute_frame_async` alongside the existing mixin handlers.
- Implements the mixin in `ArchitectureFrame` (replaces fragile direct `getattr(context, ...)` reads) and `SecurityFrame` (stores data for future use).

## Changed files
- `src/warden/validation/domain/mixins.py` -- new `CodeGraphAware` mixin
- `src/warden/pipeline/application/orchestrator/frame_runner.py` -- injection block
- `src/warden/validation/frames/architecture/architecture_frame.py` -- implements mixin
- `src/warden/validation/frames/security/frame.py` -- implements mixin

## Test plan
- [x] `pytest tests/ -k "architecture"` -- 63 passed, 4 skipped
- [x] `pytest tests/ -k "security_frame"` -- all passing
- [x] `pytest tests/ -k "mixin or code_graph"` -- 83 passed, 4 skipped
- [x] Verified the pre-existing `test_security_frame_prefers_shared_paths` event-loop failure is unrelated (fails identically on `dev`)