### PR TITLE
fix(frames): add missing context parameter to 6 frames

### DIFF
--- a/src/warden/validation/frames/antipattern/antipattern_frame.py
+++ b/src/warden/validation/frames/antipattern/antipattern_frame.py
@@ -23,9 +23,11 @@ Author: Warden Team
 Version: 3.0.0 (Universal AST)
 """
 
+from __future__ import annotations
+
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from warden.ast.application.provider_registry import ASTProviderRegistry
 from warden.ast.domain.enums import CodeLanguage
@@ -59,6 +61,9 @@ from warden.validation.frames.antipattern.types import (
     AntiPatternSeverity,
     AntiPatternViolation,
 )
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -155,7 +160,7 @@ class AntiPatternFrame(ValidationFrame):
                 pass
         return cls._registry
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """Execute anti-pattern detection on a code file."""
         start_time = time.perf_counter()
 

--- a/src/warden/validation/frames/fuzz/fuzz_frame.py
+++ b/src/warden/validation/frames/fuzz/fuzz_frame.py
@@ -10,9 +10,11 @@ Tests code behavior with unexpected/malformed inputs:
 Priority: MEDIUM
 """
 
+from __future__ import annotations
+
 import re
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from warden.llm.prompts.tool_instructions import get_tool_enhanced_prompt
 from warden.shared.infrastructure.logging import get_logger
@@ -29,6 +31,9 @@ from warden.validation.domain.frame import (
     ValidationFrame,
 )
 from warden.validation.domain.mixins import TaintAware
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -131,7 +136,7 @@ Output must be a valid JSON object with the following structure:
         """TaintAware implementation — receive shared taint analysis results."""
         self._taint_paths = taint_paths
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Execute fuzz testing checks on code file.
 

--- a/src/warden/validation/frames/gitchanges/gitchanges_frame.py
+++ b/src/warden/validation/frames/gitchanges/gitchanges_frame.py
@@ -14,11 +14,13 @@ Usage in CI/CD:
     - Focus on new code quality
 """
 
+from __future__ import annotations
+
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # Add current directory to path for local imports
 if str(Path(__file__).parent) not in sys.path:
@@ -39,6 +41,9 @@ from warden.validation.domain.frame import (
     FrameResult,
     ValidationFrame,
 )
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -91,7 +96,7 @@ class GitChangesFrame(ValidationFrame):
         # Parser
         self.diff_parser = GitDiffParser()
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Execute git changes analysis on code file.
 

--- a/src/warden/validation/frames/orphan/orphan_frame.py
+++ b/src/warden/validation/frames/orphan/orphan_frame.py
@@ -15,12 +15,14 @@ NEW: LLM-powered intelligent filtering (optional)
 Priority: MEDIUM (warning)
 """
 
+from __future__ import annotations
+
 import fnmatch
 import os
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from warden.validation.domain.enums import (
     FrameApplicability,
@@ -45,6 +47,9 @@ from llm_orphan_filter import LLMOrphanFilter
 from orphan_detector import OrphanDetectorFactory, OrphanFinding
 
 from warden.shared.infrastructure.logging import get_logger
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -329,7 +334,7 @@ class OrphanFrame(ValidationFrame, BatchExecutable, ProjectContextAware, LSPAwar
         else:
             return f"Analyzed {candidates} candidates from {file_count} files."
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Execute orphan code detection on code file.
 

--- a/src/warden/validation/frames/property/property_frame.py
+++ b/src/warden/validation/frames/property/property_frame.py
@@ -10,10 +10,12 @@ Validates business logic correctness:
 Priority: HIGH
 """
 
+from __future__ import annotations
+
 import json as _json
 import re
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from warden.llm.prompts.tool_instructions import get_tool_enhanced_prompt
 from warden.shared.infrastructure.logging import get_logger
@@ -30,6 +32,9 @@ from warden.validation.domain.frame import (
     ValidationFrame,
 )
 from warden.validation.domain.mixins import BatchExecutable
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -365,7 +370,7 @@ For EACH file, output a JSON object. Return a JSON array where each element corr
                 logger.warning("property_serial_fallback_failed", file=code_file.path, error=str(e))
         return findings_map
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Execute property testing checks on code file.
 

--- a/src/warden/validation/frames/spec/spec_frame.py
+++ b/src/warden/validation/frames/spec/spec_frame.py
@@ -30,9 +30,11 @@ Author: Warden Team
 Version: 1.0.0
 """
 
+from __future__ import annotations
+
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from warden.shared.infrastructure.logging import get_logger
 from warden.shared.infrastructure.resilience import (
@@ -64,6 +66,9 @@ from warden.validation.frames.spec.models import (
     PlatformRole,
     SpecAnalysisResult,
 )
+
+if TYPE_CHECKING:
+    from warden.pipeline.domain.pipeline_context import PipelineContext
 
 logger = get_logger(__name__)
 
@@ -323,7 +328,7 @@ class SpecFrame(ValidationFrame, Cleanable, ProjectContextAware):
 
         return fnmatch.fnmatch(gap_key, rule)
 
-    async def execute_async(self, code_file: CodeFile) -> FrameResult:
+    async def execute_async(self, code_file: CodeFile, context: PipelineContext | None = None) -> FrameResult:
         """
         Execute spec analysis asynchronously.
 


### PR DESCRIPTION
## Summary
- Added optional `context: PipelineContext | None = None` parameter to `execute_async` in 6 frames that were missing it
- Added `from __future__ import annotations` and `TYPE_CHECKING` imports to each file for proper type annotation support
- Aligns all frame signatures with the `ValidationFrame` base class abstract method definition

## Affected Frames
| Frame | File |
|-------|------|
| AntiPatternFrame | `src/warden/validation/frames/antipattern/antipattern_frame.py` |
| GitChangesFrame | `src/warden/validation/frames/gitchanges/gitchanges_frame.py` |
| PropertyFrame | `src/warden/validation/frames/property/property_frame.py` |
| SpecFrame | `src/warden/validation/frames/spec/spec_frame.py` |
| OrphanFrame | `src/warden/validation/frames/orphan/orphan_frame.py` |
| FuzzFrame | `src/warden/validation/frames/fuzz/fuzz_frame.py` |

## Context
`frame_runner.py` uses `inspect.signature()` to check whether a frame's `execute_async` accepts a `context` parameter. Frames without the parameter were called without context, preventing them from receiving project intelligence via `PipelineContext`.

This is a backward-compatible change -- the parameter defaults to `None`, so no callers need to be updated.

## Test plan
- [x] Verified 579 frame validation tests pass (all failures are pre-existing/unrelated)
- [x] Confirmed the pre-existing test failure in `test_orchestrator_rules.py` (timeout) exists on `main` as well
- [x] Confirmed the pre-existing test failure in `test_orphan_frame.py::test_orphan_frame_unused_imports` exists on `main` as well
- [x] Verified `inspect.signature` will now detect `context` in all 6 frames

Closes #139