### PR TITLE
ux(scan): live findings counter on spinner row during validation

### DIFF
--- a/src/warden/cli/commands/scan.py
+++ b/src/warden/cli/commands/scan.py
@@ -657,6 +657,7 @@ async def _process_stream_events(
     _phase_passed = 0
     _phase_failed = 0
     _phase_issues = 0
+    _total_issues_so_far = 0  # cumulative findings across all phases
     _phase_start = time.monotonic()
     _last_phase = ""  # prevent duplicate headers
     _phase_steps: list[str] = []  # progress_update status strings for subtitle
@@ -727,12 +728,14 @@ async def _process_stream_events(
         counter_str = f" ({processed_units}/{total_units})" if total_units > 0 else ""
         frame_hint = f"  [dim]{current_frame}[/dim]" if current_frame and current_frame != current_phase else ""
 
+        issues_str = f"  [bold red]{_total_issues_so_far} issue{'s' if _total_issues_so_far != 1 else ''}[/bold red]" if _total_issues_so_far > 0 else ""
+
         active_tbl = Table.grid(padding=(0, 1))
         active_tbl.add_column(no_wrap=True)
         active_tbl.add_column(no_wrap=False)
         active_tbl.add_row(
             _spinner_widget,
-            Text.from_markup(f"[white]{current_phase}[/white]{frame_hint}[dim]{counter_str}[/dim]{clock_str}"),
+            Text.from_markup(f"[white]{current_phase}[/white]{frame_hint}[dim]{counter_str}[/dim]{clock_str}{issues_str}"),
         )
 
         # ── Build content block ──────────────────────────────────────────────
@@ -863,6 +866,7 @@ async def _process_stream_events(
                             icon, color = "–", "dim"
 
                         _phase_issues += findings_num
+                        _total_issues_so_far += findings_num
                         current_frame = nonlocal_frame_name
 
                         # ── Critical finding flash row ─────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a cumulative `_total_issues_so_far` counter that tracks findings across all phases during a scan
- Increments the counter on each `frame_completed` event using existing `findings_num` data
- Displays `N issues` (bold red) on the active spinner row when count > 0, providing real-time feedback during long validation phases

**Before:** `⠦ Validation  SecurityFrame (245/543)  05:22`
**After:** `⠦ Validation  SecurityFrame (245/543)  05:22  3 issues`

## Test plan
- [ ] Run `warden scan` on a project with known issues and verify the spinner row shows the cumulative issue count
- [ ] Confirm singular form ("1 issue") displays correctly for exactly one finding
- [ ] Confirm no issues label appears when count is zero
- [ ] Verify counter persists across phase transitions (cumulative, not per-phase)

Closes #188