### PR TITLE
feat(taint): externalize taint catalog to YAML config (#73)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ warden = "warden.main:main"
 
 [tool.setuptools.package-data]
 "warden" = [
+    "validation/frames/security/_internal/*.yaml",
     "validation/frames/security/models/**/*.yaml",
     "validation/frames/security/models/*.yaml",
     "templates/**/*",

--- a/src/warden/validation/frames/security/_internal/taint_catalog.py
+++ b/src/warden/validation/frames/security/_internal/taint_catalog.py
@@ -1,8 +1,11 @@
 """
 Taint Catalog — default + user-extensible sources/sinks/sanitizers.
 
-The default catalog is built from the hardcoded constants in taint_analyzer.py.
-Users can extend (never replace) it via .warden/taint_catalog.yaml.
+Load order (fallback chain):
+  1. Default YAML catalog (taint_catalog.yaml, shipped alongside this module)
+  2. Hardcoded Python constants (taint_analyzer.py) — ultimate fallback if YAML missing/broken
+  3. YAML model packs (models/{lang}/*.yaml) — unioned on top
+  4. .warden/taint_catalog.yaml — user project-level overrides (union, never replace)
 
 YAML format (.warden/taint_catalog.yaml):
     sources:
@@ -37,18 +40,21 @@ logger = logging.getLogger(__name__)
 _CATALOG_FILENAME = "taint_catalog.yaml"
 _WARDEN_DIR = ".warden"
 
+# Default YAML catalog shipped alongside this module
+_DEFAULT_CATALOG_PATH = Path(__file__).with_suffix(".yaml")
+
 
 @dataclass
 class TaintCatalog:
     """
     Taint analysis catalog: sources, sinks, sanitizers.
 
-    sources:      lang → set of source patterns
+    sources:      lang -> set of source patterns
                   {"python": {"request.args", ...}, "javascript": {"req.body", ...}}
-    sinks:        sink_name → sink_type (Python + JS combined)
+    sinks:        sink_name -> sink_type (Python + JS combined)
                   {"cursor.execute": "SQL-value", "eval": "CODE-execution", ...}
     assign_sinks: JS DOM property assignment sinks (innerHTML, outerHTML)
-    sanitizers:   sink_type → set of sanitizer functions
+    sanitizers:   sink_type -> set of sanitizer functions
                   {"SQL-value": {"parameterized_query", ...}, ...}
     """
 
@@ -57,17 +63,98 @@ class TaintCatalog:
     assign_sinks: set[str] = field(default_factory=set)
     sanitizers: dict[str, set[str]] = field(default_factory=dict)
 
+    # ── Default YAML loading ─────────────────────────────────────────────
+
     @classmethod
-    def get_default(cls) -> TaintCatalog:
+    def _load_default_yaml(cls) -> TaintCatalog | None:
         """
-        Build a TaintCatalog from hardcoded constants + built-in YAML model packs.
+        Load the default YAML catalog shipped with this module.
 
-        Load order:
-          1. Hardcoded constants (taint_analyzer.py) — always included as baseline
-          2. YAML model packs (models/{lang}/*.yaml) — unioned on top
+        Returns a TaintCatalog if the file exists and parses correctly,
+        or None if the file is missing/malformed (caller falls back to hardcoded).
+        """
+        if not _DEFAULT_CATALOG_PATH.exists():
+            logger.debug("default_catalog_yaml_missing path=%s", _DEFAULT_CATALOG_PATH)
+            return None
 
-        If the models/ directory is missing or all files fail to load, only the
-        hardcoded constants are used (unchanged backward-compatible behaviour).
+        try:
+            import yaml
+
+            with open(_DEFAULT_CATALOG_PATH, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+
+            if not isinstance(data, dict):
+                logger.warning("default_catalog_yaml_invalid_format path=%s", _DEFAULT_CATALOG_PATH)
+                return None
+
+            return cls._parse_default_yaml(data)
+
+        except Exception as exc:
+            logger.warning("default_catalog_yaml_load_failed path=%s error=%s", _DEFAULT_CATALOG_PATH, exc)
+            return None
+
+    @classmethod
+    def _parse_default_yaml(cls, data: dict[str, Any]) -> TaintCatalog:
+        """Parse the default YAML catalog format into a TaintCatalog instance.
+
+        Default YAML format (different from user override format):
+          sources:   {lang: [pattern, ...]}
+          sinks:     {sink_name: sink_type}   (flat mapping, NOT grouped by type)
+          sanitizers: {sink_type: [sanitizer, ...]}
+          assign_sinks: [pattern, ...]
+        """
+        # ── Sources ──────────────────────────────────────────────────────
+        sources: dict[str, set[str]] = {}
+        raw_sources = data.get("sources") or {}
+        if isinstance(raw_sources, dict):
+            for lang, entries in raw_sources.items():
+                if isinstance(entries, list):
+                    valid = {e for e in entries if isinstance(e, str) and e.strip()}
+                    if valid:
+                        sources[lang] = valid
+
+        # ── Sinks ────────────────────────────────────────────────────────
+        sinks: dict[str, str] = {}
+        raw_sinks = data.get("sinks") or {}
+        if isinstance(raw_sinks, dict):
+            for sink_name, sink_type in raw_sinks.items():
+                if isinstance(sink_name, str) and isinstance(sink_type, str):
+                    sinks[sink_name] = sink_type
+
+        # ── Sanitizers ───────────────────────────────────────────────────
+        sanitizers: dict[str, set[str]] = {}
+        raw_sanitizers = data.get("sanitizers") or {}
+        if isinstance(raw_sanitizers, dict):
+            for sink_type, entries in raw_sanitizers.items():
+                if isinstance(entries, list):
+                    valid = {e for e in entries if isinstance(e, str) and e.strip()}
+                    sanitizers[sink_type] = valid
+                elif entries is None:
+                    # Explicit empty (e.g., CODE-execution: [])
+                    sanitizers[sink_type] = set()
+
+        # ── Assign sinks ─────────────────────────────────────────────────
+        assign_sinks: set[str] = set()
+        raw_assign = data.get("assign_sinks") or []
+        if isinstance(raw_assign, list):
+            assign_sinks = {e for e in raw_assign if isinstance(e, str) and e.strip()}
+
+        return cls(
+            sources=sources,
+            sinks=sinks,
+            assign_sinks=assign_sinks,
+            sanitizers=sanitizers,
+        )
+
+    # ── Hardcoded fallback ───────────────────────────────────────────────
+
+    @classmethod
+    def _build_from_hardcoded(cls) -> TaintCatalog:
+        """
+        Build a TaintCatalog from hardcoded constants in taint_analyzer.py.
+
+        This is the ultimate fallback when the default YAML catalog is
+        missing or fails to load.
         """
         # Late import to avoid circular dependency at module level
         from warden.validation.frames.security._internal.taint_analyzer import (
@@ -80,7 +167,6 @@ class TaintCatalog:
             TAINT_SOURCES,
         )
 
-        # ── Baseline from hardcoded constants ─────────────────────────────────
         combined_sinks: dict[str, str] = {}
         combined_sinks.update(TAINT_SINKS)
         combined_sinks.update(JS_TAINT_SINKS)
@@ -97,7 +183,37 @@ class TaintCatalog:
         }
         combined_assign_sinks: set[str] = set(_JS_ASSIGN_SINKS)
 
-        # ── Union with YAML model packs ───────────────────────────────────────
+        return cls(
+            sources=combined_sources,
+            sinks=combined_sinks,
+            assign_sinks=combined_assign_sinks,
+            sanitizers=combined_sanitizers,
+        )
+
+    # ── Public API ───────────────────────────────────────────────────────
+
+    @classmethod
+    def get_default(cls) -> TaintCatalog:
+        """
+        Build a TaintCatalog from the default YAML + model packs.
+
+        Load order:
+          1. Default YAML catalog (taint_catalog.yaml next to this module)
+          2. Hardcoded constants (taint_analyzer.py) — fallback if YAML missing/broken
+          3. YAML model packs (models/{lang}/*.yaml) — unioned on top
+
+        If the models/ directory is missing or all files fail to load, only the
+        baseline (step 1 or 2) is used.
+        """
+        # Step 1: Try default YAML catalog first
+        catalog = cls._load_default_yaml()
+
+        # Step 2: Fall back to hardcoded constants if YAML failed
+        if catalog is None:
+            logger.debug("default_catalog_yaml_unavailable, falling_back_to_hardcoded")
+            catalog = cls._build_from_hardcoded()
+
+        # Step 3: Union with YAML model packs
         try:
             from warden.validation.frames.security._internal.model_loader import (
                 ModelPackLoader,
@@ -107,28 +223,23 @@ class TaintCatalog:
             if pack:
                 # Sources: merge per language
                 for lang, patterns in (pack.get("sources") or {}).items():
-                    combined_sources.setdefault(lang, set()).update(patterns)
+                    catalog.sources.setdefault(lang, set()).update(patterns)
 
-                # Sinks: model pack entries added (constants take precedence via update order)
+                # Sinks: model pack entries added (baseline takes precedence via setdefault)
                 for pattern, sink_type in (pack.get("sinks") or {}).items():
-                    combined_sinks.setdefault(pattern, sink_type)
+                    catalog.sinks.setdefault(pattern, sink_type)
 
                 # Assign sinks
-                combined_assign_sinks.update(pack.get("assign_sinks") or set())
+                catalog.assign_sinks.update(pack.get("assign_sinks") or set())
 
                 # Sanitizers: merge per sink_type
                 for sink_type, sans in (pack.get("sanitizers") or {}).items():
-                    combined_sanitizers.setdefault(sink_type, set()).update(sans)
+                    catalog.sanitizers.setdefault(sink_type, set()).update(sans)
 
         except Exception as exc:
             logger.warning("model_pack_load_error error=%s", exc)
 
-        return cls(
-            sources=combined_sources,
-            sinks=combined_sinks,
-            assign_sinks=combined_assign_sinks,
-            sanitizers=combined_sanitizers,
-        )
+        return catalog
 
     @classmethod
     def load(cls, project_root: Path) -> TaintCatalog:

--- a/src/warden/validation/frames/security/_internal/taint_catalog.yaml
+++ b/src/warden/validation/frames/security/_internal/taint_catalog.yaml
@@ -1,0 +1,191 @@
+# Default Taint Catalog — sources, sinks, and sanitizers.
+#
+# This file externalizes the hardcoded taint analysis catalog so that new
+# frameworks and patterns can be added without changing Python source code.
+#
+# Load order (handled by TaintCatalog):
+#   1. This file (default catalog, shipped with warden)
+#   2. YAML model packs  (models/{lang}/*.yaml) — unioned on top
+#   3. .warden/taint_catalog.yaml — user project-level overrides (union)
+#
+# Hardcoded Python constants serve as the ultimate fallback if this file
+# is missing or fails to parse.
+#
+# Format:
+#   sources:    lang -> list of source patterns
+#   sinks:      sink_name -> sink_type  (flat map, all languages combined)
+#   sanitizers: sink_type -> list of sanitizer functions
+#   assign_sinks: list of JS DOM property assignment sinks
+#
+# NOTE: When a sink name exists in both Python and JavaScript with different
+# types (e.g. "exec"), the JavaScript type takes precedence (matching the
+# original hardcoded merge order). The combined mapping is stored flat.
+
+# ── Sources (user-controlled input) ─────────────────────────────────────────
+
+sources:
+  python:
+    - request.args
+    - request.form
+    - request.json
+    - request.data
+    - request.values
+    - request.cookies
+    - request.headers
+    - request.get_json
+    - request.files
+    - input
+    - sys.argv
+    - os.environ
+    - os.getenv
+    - stdin
+    - sys.stdin
+
+  javascript:
+    # Express / Node HTTP
+    - req.body
+    - req.query
+    - req.params
+    - req.headers
+    - req.cookies
+    - request.body
+    - request.query
+    - request.params
+    - request.headers
+    - request.cookies
+    # Environment / process
+    - process.env
+    # DOM / browser
+    - document.cookie
+    - document.location
+    - window.location
+    - location.search
+    - location.hash
+    - location.href
+    - localStorage.getItem
+    - sessionStorage.getItem
+    # WebSocket / events
+    - event.data
+
+# ── Sinks (dangerous functions that should not receive tainted data) ────────
+# All languages combined in a flat mapping. For keys that appear in both
+# Python and JS with different types, the JS type is used (matching the
+# original hardcoded constant merge order: Python first, JS second).
+
+sinks:
+  # SQL sinks (Python + JS)
+  cursor.execute: SQL-value
+  cursor.executemany: SQL-value
+  connection.execute: SQL-value
+  db.execute: SQL-value
+  session.execute: SQL-value
+  engine.execute: SQL-value
+  db.query: SQL-value
+  pool.query: SQL-value
+  connection.query: SQL-value
+  client.query: SQL-value
+  sequelize.query: SQL-value
+  knex.raw: SQL-value
+
+  # Command sinks (Python + JS)
+  os.system: CMD-argument
+  os.popen: CMD-argument
+  subprocess.run: CMD-argument
+  subprocess.call: CMD-argument
+  subprocess.Popen: CMD-argument
+  # "exec" exists in both Python (CODE-execution) and JS (CMD-argument).
+  # JS wins in the original merge order.
+  exec: CMD-argument
+  execSync: CMD-argument
+  spawn: CMD-argument
+  spawnSync: CMD-argument
+  child_process.exec: CMD-argument
+  child_process.execSync: CMD-argument
+  child_process.spawn: CMD-argument
+
+  # HTML sinks (Python + JS)
+  render_template_string: HTML-content
+  Markup: HTML-content
+  innerHTML: HTML-content
+  outerHTML: HTML-content
+  document.write: HTML-content
+  document.writeln: HTML-content
+  insertAdjacentHTML: HTML-content
+
+  # Code execution sinks (Python + JS)
+  eval: CODE-execution
+  compile: CODE-execution
+  Function: CODE-execution
+  setTimeout: CODE-execution
+  setInterval: CODE-execution
+
+  # File sinks (Python + JS)
+  open: FILE-path
+  pathlib.Path: FILE-path
+  fs.readFile: FILE-path
+  fs.readFileSync: FILE-path
+  fs.writeFile: FILE-path
+  fs.writeFileSync: FILE-path
+
+  # HTTP / SSRF sinks (CWE-918) — Python only
+  requests.get: HTTP-request
+  requests.post: HTTP-request
+  requests.put: HTTP-request
+  requests.delete: HTTP-request
+  requests.patch: HTTP-request
+  requests.request: HTTP-request
+  requests.head: HTTP-request
+  urllib.request.urlopen: HTTP-request
+  urllib.request.Request: HTTP-request
+  httpx.get: HTTP-request
+  httpx.post: HTTP-request
+  httpx.put: HTTP-request
+  httpx.delete: HTTP-request
+  httpx.request: HTTP-request
+  httpx.AsyncClient.get: HTTP-request
+  httpx.AsyncClient.post: HTTP-request
+  aiohttp.ClientSession.get: HTTP-request
+  aiohttp.ClientSession.post: HTTP-request
+  aiohttp.ClientSession.request: HTTP-request
+
+# ── Sanitizers (functions that neutralize taint for a given sink type) ──────
+
+sanitizers:
+  SQL-value:
+    - parameterized_query
+    - sqlalchemy.text
+    - prepared_statement
+    - db.escape
+    - connection.escape
+    - mysql.escape
+    - sequelize.escape
+    - knex.escape
+  CMD-argument:
+    - shlex.quote
+    - shlex.split
+  HTML-content:
+    - html.escape
+    - markupsafe.escape
+    - bleach.clean
+    - DOMPurify.sanitize
+    - sanitizeHtml
+    - escapeHtml
+    - encodeURIComponent
+    - xss
+  CODE-execution: []
+  FILE-path:
+    - os.path.basename
+    - pathlib.PurePath
+    - path.basename
+    - path.resolve
+    - encodeURIComponent
+  HTTP-request:
+    - urllib.parse.urlparse
+    - ipaddress.ip_address
+    - validators.url
+
+# ── JS DOM property-assignment sinks ────────────────────────────────────────
+
+assign_sinks:
+  - innerHTML
+  - outerHTML


### PR DESCRIPTION
## Summary
- Externalize hardcoded taint source/sink/sanitizer catalog from Python dicts to a default YAML file (`taint_catalog.yaml`) shipped alongside the module
- Implement a 4-layer fallback chain: default YAML -> hardcoded Python constants -> YAML model packs -> user `.warden/taint_catalog.yaml` override
- Add the YAML file to `pyproject.toml` package-data so it ships with the wheel
- Add 11 new tests covering YAML loading, fallback behavior, and YAML-vs-hardcoded consistency

## Test plan
- [x] All 125 taint-related tests pass (`pytest -k taint`)
- [x] New `TestTaintCatalogDefaultYaml` class validates YAML file existence, parsing, content, and fallback
- [x] `test_yaml_and_hardcoded_produce_same_baseline` ensures YAML matches hardcoded constants exactly
- [x] Fallback to hardcoded works when YAML is missing or malformed
- [x] Existing user-override (`.warden/taint_catalog.yaml`) behavior unchanged

Closes #73