### PR TITLE
feat(taint): add URL-fetch and LOG-output sink types (#91, #89)

### DIFF
--- a/src/warden/validation/frames/security/_internal/taint_analyzer.py
+++ b/src/warden/validation/frames/security/_internal/taint_analyzer.py
@@ -192,6 +192,20 @@ TAINT_SINKS: dict[str, str] = {
     "aiohttp.ClientSession.get": "HTTP-request",
     "aiohttp.ClientSession.post": "HTTP-request",
     "aiohttp.ClientSession.request": "HTTP-request",
+    # LOG-output / PII leak sinks — logging functions that may expose sensitive data
+    "logging.info": "LOG-output",
+    "logging.debug": "LOG-output",
+    "logging.warning": "LOG-output",
+    "logging.error": "LOG-output",
+    "logging.critical": "LOG-output",
+    "logging.exception": "LOG-output",
+    "logger.info": "LOG-output",
+    "logger.debug": "LOG-output",
+    "logger.warning": "LOG-output",
+    "logger.error": "LOG-output",
+    "logger.critical": "LOG-output",
+    "logger.exception": "LOG-output",
+    "print": "LOG-output",
 }
 
 # Known sanitizers
@@ -203,6 +217,8 @@ KNOWN_SANITIZERS: dict[str, set[str]] = {
     "FILE-path": {"os.path.basename", "pathlib.PurePath"},
     # SSRF mitigation: allowlist / URL validation functions
     "HTTP-request": {"urllib.parse.urlparse", "ipaddress.ip_address", "validators.url"},
+    # PII masking / log sanitization
+    "LOG-output": {"mask_pii", "redact", "sanitize_log", "PIIMaskingFilter", "mask_sensitive", "scrub", "anonymize", "re.sub"},
 }
 
 
@@ -269,6 +285,35 @@ JS_TAINT_SINKS: dict[str, str] = {
     "fs.readFileSync": "FILE-path",
     "fs.writeFile": "FILE-path",
     "fs.writeFileSync": "FILE-path",
+    # URL-fetch / SSRF sinks (CWE-918) — user-controlled URLs in JS HTTP clients
+    "fetch": "URL-fetch",
+    "axios": "URL-fetch",
+    "axios.get": "URL-fetch",
+    "axios.post": "URL-fetch",
+    "axios.put": "URL-fetch",
+    "axios.delete": "URL-fetch",
+    "axios.request": "URL-fetch",
+    "http.request": "URL-fetch",
+    "http.get": "URL-fetch",
+    "https.request": "URL-fetch",
+    "https.get": "URL-fetch",
+    "got": "URL-fetch",
+    "got.get": "URL-fetch",
+    "got.post": "URL-fetch",
+    "node-fetch": "URL-fetch",
+    "undici.fetch": "URL-fetch",
+    "undici.request": "URL-fetch",
+    # LOG-output / PII leak sinks — JS logging that may expose sensitive data
+    "console.log": "LOG-output",
+    "console.error": "LOG-output",
+    "console.warn": "LOG-output",
+    "console.debug": "LOG-output",
+    "console.info": "LOG-output",
+    "console.trace": "LOG-output",
+    "logger.info": "LOG-output",
+    "logger.error": "LOG-output",
+    "logger.warn": "LOG-output",
+    "logger.debug": "LOG-output",
 }
 
 # Property-assignment sinks (element.innerHTML = ...)
@@ -280,6 +325,10 @@ JS_SANITIZERS: dict[str, set[str]] = {
     "HTML-content": {"DOMPurify.sanitize", "sanitizeHtml", "escapeHtml", "encodeURIComponent", "xss"},
     "CODE-execution": set(),
     "FILE-path": {"path.basename", "path.resolve", "encodeURIComponent"},
+    # SSRF mitigation for JS: URL validation / allowlist checking
+    "URL-fetch": {"url.parse", "new URL", "validator.isURL", "isValidUrl", "allowedHosts.includes", "URL.canParse"},
+    # PII masking / log sanitization for JS
+    "LOG-output": {"mask_pii", "redact", "sanitize_log", "mask_sensitive", "scrub", "anonymize"},
 }
 
 # ── Regex helpers ───────────────────────────────────────────────────────────

--- a/src/warden/validation/frames/security/_internal/taint_catalog.yaml
+++ b/src/warden/validation/frames/security/_internal/taint_catalog.yaml
@@ -148,6 +148,54 @@ sinks:
   aiohttp.ClientSession.post: HTTP-request
   aiohttp.ClientSession.request: HTTP-request
 
+  # URL-fetch / SSRF sinks (CWE-918) — JavaScript / TypeScript
+  # Browser and Node.js HTTP client functions that accept user-controlled URLs.
+  fetch: URL-fetch
+  axios: URL-fetch
+  axios.get: URL-fetch
+  axios.post: URL-fetch
+  axios.put: URL-fetch
+  axios.delete: URL-fetch
+  axios.request: URL-fetch
+  http.request: URL-fetch
+  http.get: URL-fetch
+  https.request: URL-fetch
+  https.get: URL-fetch
+  got: URL-fetch
+  got.get: URL-fetch
+  got.post: URL-fetch
+  node-fetch: URL-fetch
+  undici.fetch: URL-fetch
+  undici.request: URL-fetch
+
+  # LOG-output / PII leak sinks — Python
+  # Logging functions that may inadvertently expose sensitive/PII data.
+  logging.info: LOG-output
+  logging.debug: LOG-output
+  logging.warning: LOG-output
+  logging.error: LOG-output
+  logging.critical: LOG-output
+  logging.exception: LOG-output
+  logger.info: LOG-output
+  logger.debug: LOG-output
+  logger.warning: LOG-output
+  logger.error: LOG-output
+  logger.critical: LOG-output
+  logger.exception: LOG-output
+  print: LOG-output
+
+  # LOG-output / PII leak sinks — JavaScript / TypeScript
+  console.log: LOG-output
+  console.error: LOG-output
+  console.warn: LOG-output
+  console.debug: LOG-output
+  console.info: LOG-output
+  console.trace: LOG-output
+  logger.info: LOG-output
+  logger.error: LOG-output
+  logger.warn: LOG-output
+  logger.debug: LOG-output
+
 # ── Sanitizers (functions that neutralize taint for a given sink type) ──────
 
 sanitizers:
@@ -183,6 +231,22 @@ sanitizers:
     - urllib.parse.urlparse
     - ipaddress.ip_address
     - validators.url
+  URL-fetch:
+    - url.parse
+    - new URL
+    - validator.isURL
+    - isValidUrl
+    - allowedHosts.includes
+    - URL.canParse
+  LOG-output:
+    - mask_pii
+    - redact
+    - sanitize_log
+    - PIIMaskingFilter
+    - mask_sensitive
+    - scrub
+    - anonymize
+    - re.sub
 
 # ── JS DOM property-assignment sinks ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **URL-fetch sinks (Issue #91, CWE-918):** Added `URL-fetch` sink type for JavaScript/TypeScript SSRF detection covering `fetch()`, `axios.get/post/put/delete/request`, `http.request`, `http.get`, `https.request`, `https.get`, `got`, `node-fetch`, `undici.fetch/request`. Includes sanitizers: `url.parse`, `new URL`, `validator.isURL`, `isValidUrl`, `allowedHosts.includes`, `URL.canParse`.
- **LOG-output sinks (Issue #89):** Added `LOG-output` sink type for PII leak detection covering Python (`logging.info/debug/warning/error/critical/exception`, `logger.info/debug/warning/error/critical/exception`, `print`) and JavaScript (`console.log/error/warn/debug/info/trace`, `logger.info/error/warn/debug`). Includes sanitizers: `mask_pii`, `redact`, `sanitize_log`, `PIIMaskingFilter`, `mask_sensitive`, `scrub`, `anonymize`, `re.sub`.
- Updated the externalized YAML catalog (`taint_catalog.yaml`), hardcoded fallback constants (`taint_analyzer.py`), and test coverage (`test_taint_catalog.py`).

## Changed files

- `src/warden/validation/frames/security/_internal/taint_catalog.yaml` -- new sink entries and sanitizers
- `src/warden/validation/frames/security/_internal/taint_analyzer.py` -- hardcoded fallback constants for URL-fetch + LOG-output
- `tests/validation/frames/security/test_taint_catalog.py` -- new tests for both sink types, updated coverage assertions

## Test plan

- [x] `python3 -m pytest tests/ -k "taint" -x` -- all 134 taint tests pass
- [x] Existing SSRF tests (`test_ssrf_detection.py`) still pass unchanged
- [x] YAML/hardcoded parity test (`test_yaml_and_hardcoded_produce_same_baseline`) passes
- [x] Clean code tests still return zero paths (no false positives from new LOG-output sinks)

Closes #91, closes #89