### PR TITLE
fix(llm): add provider-level circuit breaker to prevent cascading timeouts

### DIFF
--- a/src/warden/llm/circuit_breaker.py
+++ b/src/warden/llm/circuit_breaker.py
@@ -1,0 +1,200 @@
+"""
+Provider-level circuit breaker for LLM orchestration.
+
+Prevents cascading timeouts when a provider is repeatedly failing.
+Instead of waiting for full timeout on every request (e.g., 5 frames x 3 retries x 30s = 450s),
+an open circuit fails fast and the orchestrator skips to the next provider immediately.
+
+States:
+    CLOSED  - Provider is healthy, requests flow normally.
+    OPEN    - Provider has exceeded failure threshold, requests are rejected immediately.
+    HALF_OPEN - After open_duration elapses, allow one probe request to test recovery.
+
+Usage:
+    cb = ProviderCircuitBreaker()
+    if cb.is_open(provider):
+        skip provider
+    try:
+        response = await provider.send_async(request)
+        cb.record_success(provider)
+    except Exception:
+        cb.record_failure(provider)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import timedelta
+from enum import Enum
+
+from warden.shared.infrastructure.logging import get_logger
+
+from .types import LlmProvider
+
+logger = get_logger(__name__)
+
+
+class ProviderCircuitState(Enum):
+    """Circuit breaker states per provider."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+@dataclass
+class _ProviderState:
+    """Internal state tracking for a single provider's circuit breaker."""
+
+    state: ProviderCircuitState = ProviderCircuitState.CLOSED
+    failure_count: int = 0
+    success_count: int = 0
+    last_failure_time: float | None = None
+    last_state_change: float = field(default_factory=time.time)
+
+
+class ProviderCircuitBreaker:
+    """Orchestrator-level circuit breaker that tracks failures per LLM provider.
+
+    This is intentionally separate from the per-provider ``@resilient`` decorator.
+    The ``@resilient`` decorator handles retries and timeouts *within* a single
+    provider call.  This circuit breaker sits *above* that layer in the orchestrator
+    and decides whether to even *attempt* a provider based on its recent track record.
+
+    Parameters:
+        fail_threshold: Number of consecutive failures before opening the circuit.
+        open_duration: How long the circuit stays open before transitioning to half-open.
+        success_threshold: Number of consecutive successes in half-open state
+                           required to close the circuit again.
+    """
+
+    def __init__(
+        self,
+        fail_threshold: int = 3,
+        open_duration: timedelta = timedelta(minutes=5),
+        success_threshold: int = 1,
+    ) -> None:
+        self.fail_threshold = fail_threshold
+        self.open_duration = open_duration
+        self.success_threshold = success_threshold
+        self._states: dict[LlmProvider, _ProviderState] = {}
+
+    def _get_state(self, provider: LlmProvider) -> _ProviderState:
+        """Get or create state for a provider."""
+        if provider not in self._states:
+            self._states[provider] = _ProviderState()
+        return self._states[provider]
+
+    def _maybe_transition_to_half_open(self, provider: LlmProvider, state: _ProviderState) -> None:
+        """Check if an OPEN circuit should transition to HALF_OPEN."""
+        if state.state != ProviderCircuitState.OPEN:
+            return
+        if state.last_failure_time is None:
+            return
+        elapsed = time.time() - state.last_failure_time
+        if elapsed >= self.open_duration.total_seconds():
+            state.state = ProviderCircuitState.HALF_OPEN
+            state.success_count = 0
+            state.last_state_change = time.time()
+            logger.info(
+                "provider_circuit_half_open",
+                provider=provider.value,
+                elapsed_seconds=round(elapsed, 1),
+                message="Circuit transitioned to half-open, allowing probe request",
+            )
+
+    def get_state(self, provider: LlmProvider) -> ProviderCircuitState:
+        """Get the current circuit state for a provider, applying time-based transitions."""
+        state = self._get_state(provider)
+        self._maybe_transition_to_half_open(provider, state)
+        return state.state
+
+    def is_open(self, provider: LlmProvider) -> bool:
+        """Check if a provider's circuit is open (should be skipped).
+
+        Returns True only when the circuit is in the OPEN state.
+        HALF_OPEN returns False to allow a probe request through.
+        """
+        return self.get_state(provider) == ProviderCircuitState.OPEN
+
+    def record_failure(self, provider: LlmProvider) -> None:
+        """Record a failure for a provider.
+
+        In CLOSED state: increments failure count; opens circuit if threshold reached.
+        In HALF_OPEN state: immediately re-opens the circuit (probe failed).
+        In OPEN state: no-op (shouldn't happen if callers check is_open first).
+        """
+        state = self._get_state(provider)
+        state.failure_count += 1
+        state.last_failure_time = time.time()
+
+        if state.state == ProviderCircuitState.CLOSED:
+            if state.failure_count >= self.fail_threshold:
+                state.state = ProviderCircuitState.OPEN
+                state.last_state_change = time.time()
+                logger.warning(
+                    "provider_circuit_opened",
+                    provider=provider.value,
+                    failure_count=state.failure_count,
+                    open_duration_seconds=self.open_duration.total_seconds(),
+                    message=(
+                        f"Provider circuit opened after {state.failure_count} consecutive failures. "
+                        f"Will skip for {self.open_duration.total_seconds()}s."
+                    ),
+                )
+        elif state.state == ProviderCircuitState.HALF_OPEN:
+            # Probe request failed -- back to OPEN
+            state.state = ProviderCircuitState.OPEN
+            state.last_state_change = time.time()
+            logger.warning(
+                "provider_circuit_reopened",
+                provider=provider.value,
+                message="Half-open probe failed, circuit re-opened",
+            )
+
+    def record_success(self, provider: LlmProvider) -> None:
+        """Record a success for a provider.
+
+        In CLOSED state: resets failure count (provider is healthy).
+        In HALF_OPEN state: increments success count; closes circuit if threshold reached.
+        In OPEN state: no-op (shouldn't happen if callers check is_open first).
+        """
+        state = self._get_state(provider)
+
+        if state.state == ProviderCircuitState.CLOSED:
+            # Reset failure count on success -- provider is healthy
+            state.failure_count = 0
+        elif state.state == ProviderCircuitState.HALF_OPEN:
+            state.success_count += 1
+            if state.success_count >= self.success_threshold:
+                state.state = ProviderCircuitState.CLOSED
+                state.failure_count = 0
+                state.success_count = 0
+                state.last_state_change = time.time()
+                logger.info(
+                    "provider_circuit_closed",
+                    provider=provider.value,
+                    message="Provider recovered, circuit closed",
+                )
+
+    def reset(self, provider: LlmProvider) -> None:
+        """Manually reset a provider's circuit to CLOSED state."""
+        if provider in self._states:
+            self._states[provider] = _ProviderState()
+            logger.info(
+                "provider_circuit_reset",
+                provider=provider.value,
+                message="Circuit manually reset to closed",
+            )
+
+    def get_open_providers(self) -> list[LlmProvider]:
+        """Return list of providers whose circuits are currently open."""
+        return [p for p in self._states if self.is_open(p)]
+
+    def summary(self) -> dict[str, str]:
+        """Return a summary of all tracked provider circuit states."""
+        result = {}
+        for provider in self._states:
+            result[provider.value] = self.get_state(provider).value
+        return result

--- a/tests/llm/test_circuit_breaker.py
+++ b/tests/llm/test_circuit_breaker.py
@@ -1,0 +1,414 @@
+"""
+Tests for warden.llm.circuit_breaker.ProviderCircuitBreaker.
+
+Covers:
+1. CLOSED -> OPEN transition after fail_threshold consecutive failures
+2. OPEN -> HALF_OPEN transition after open_duration elapses
+3. HALF_OPEN -> CLOSED transition after success_threshold successes
+4. HALF_OPEN -> OPEN re-transition on probe failure
+5. Success resets failure count in CLOSED state
+6. is_open returns True only in OPEN state
+7. get_open_providers and summary helpers
+8. reset manually closes a circuit
+9. Integration with OrchestratedLlmClient - fast tier skips open-circuit providers
+10. Integration with OrchestratedLlmClient - smart tier fallback skips open-circuit providers
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from warden.llm.circuit_breaker import ProviderCircuitBreaker, ProviderCircuitState
+from warden.llm.providers.orchestrated import OrchestratedLlmClient
+from warden.llm.types import LlmProvider, LlmRequest, LlmResponse
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(provider_val: LlmProvider = LlmProvider.OLLAMA, available: bool = True) -> AsyncMock:
+    client = AsyncMock()
+    client.provider = provider_val
+    client.is_available_async = AsyncMock(return_value=available)
+    return client
+
+
+def _success_response(content: str = "ok", provider: LlmProvider = LlmProvider.OLLAMA) -> LlmResponse:
+    return LlmResponse(content=content, success=True, provider=provider, model="test")
+
+
+def _fail_response(error: str = "fail", provider: LlmProvider = LlmProvider.OLLAMA) -> LlmResponse:
+    return LlmResponse(content="", success=False, error_message=error, provider=provider, model="test")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ProviderCircuitBreaker
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCircuitBreakerStates:
+    """Test state transitions of the provider circuit breaker."""
+
+    def test_initial_state_is_closed(self):
+        """New provider starts in CLOSED state."""
+        cb = ProviderCircuitBreaker()
+        assert cb.get_state(LlmProvider.OLLAMA) == ProviderCircuitState.CLOSED
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+    def test_opens_after_fail_threshold(self):
+        """Circuit opens after fail_threshold consecutive failures."""
+        cb = ProviderCircuitBreaker(fail_threshold=3)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is True
+
+    def test_success_resets_failure_count(self):
+        """A success in CLOSED state resets the failure count."""
+        cb = ProviderCircuitBreaker(fail_threshold=3)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.OLLAMA)
+        # 2 failures, one more would open
+
+        cb.record_success(LlmProvider.OLLAMA)
+        # Should reset count
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.OLLAMA)
+        # Only 2 failures since reset, not 3
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+    def test_transitions_to_half_open_after_duration(self):
+        """After open_duration, circuit transitions to HALF_OPEN."""
+        cb = ProviderCircuitBreaker(
+            fail_threshold=1,
+            open_duration=timedelta(seconds=1),
+        )
+
+        cb.record_failure(LlmProvider.GROQ)
+        assert cb.is_open(LlmProvider.GROQ) is True
+
+        # Simulate time passing
+        state = cb._get_state(LlmProvider.GROQ)
+        state.last_failure_time = time.time() - 2  # 2 seconds ago
+
+        assert cb.get_state(LlmProvider.GROQ) == ProviderCircuitState.HALF_OPEN
+        assert cb.is_open(LlmProvider.GROQ) is False  # HALF_OPEN allows probe
+
+    def test_half_open_success_closes_circuit(self):
+        """Success in HALF_OPEN transitions to CLOSED."""
+        cb = ProviderCircuitBreaker(
+            fail_threshold=1,
+            open_duration=timedelta(seconds=1),
+            success_threshold=1,
+        )
+
+        # Open the circuit
+        cb.record_failure(LlmProvider.GROQ)
+        assert cb.is_open(LlmProvider.GROQ) is True
+
+        # Simulate time passing to reach HALF_OPEN
+        state = cb._get_state(LlmProvider.GROQ)
+        state.last_failure_time = time.time() - 2
+
+        assert cb.get_state(LlmProvider.GROQ) == ProviderCircuitState.HALF_OPEN
+
+        # Probe succeeds
+        cb.record_success(LlmProvider.GROQ)
+        assert cb.get_state(LlmProvider.GROQ) == ProviderCircuitState.CLOSED
+        assert cb.is_open(LlmProvider.GROQ) is False
+
+    def test_half_open_failure_reopens_circuit(self):
+        """Failure in HALF_OPEN transitions back to OPEN."""
+        cb = ProviderCircuitBreaker(
+            fail_threshold=1,
+            open_duration=timedelta(seconds=1),
+        )
+
+        # Open the circuit
+        cb.record_failure(LlmProvider.GROQ)
+
+        # Simulate time passing to reach HALF_OPEN
+        state = cb._get_state(LlmProvider.GROQ)
+        state.last_failure_time = time.time() - 2
+
+        assert cb.get_state(LlmProvider.GROQ) == ProviderCircuitState.HALF_OPEN
+
+        # Probe fails
+        cb.record_failure(LlmProvider.GROQ)
+        assert cb.is_open(LlmProvider.GROQ) is True
+
+    def test_independent_providers(self):
+        """Each provider has independent circuit state."""
+        cb = ProviderCircuitBreaker(fail_threshold=2)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is True
+
+        # GROQ should still be closed
+        assert cb.is_open(LlmProvider.GROQ) is False
+
+    def test_reset(self):
+        """Manual reset returns circuit to CLOSED."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is True
+
+        cb.reset(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+        assert cb.get_state(LlmProvider.OLLAMA) == ProviderCircuitState.CLOSED
+
+
+class TestProviderCircuitBreakerHelpers:
+    """Test helper/query methods."""
+
+    def test_get_open_providers(self):
+        """get_open_providers returns only providers with OPEN circuits."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.GROQ)
+        cb.record_success(LlmProvider.DEEPSEEK)  # Registers but stays CLOSED
+
+        open_providers = cb.get_open_providers()
+        assert LlmProvider.OLLAMA in open_providers
+        assert LlmProvider.GROQ in open_providers
+        assert LlmProvider.DEEPSEEK not in open_providers
+
+    def test_summary(self):
+        """summary returns dict of provider -> state."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_success(LlmProvider.GROQ)
+
+        result = cb.summary()
+        assert result["ollama"] == "open"
+        assert result["groq"] == "closed"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with OrchestratedLlmClient
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratedCircuitBreakerIntegration:
+    """Test circuit breaker integration in the orchestrated client."""
+
+    @pytest.mark.asyncio
+    async def test_fast_tier_skips_open_circuit_provider(self):
+        """Provider with open circuit should be skipped in fast tier racing."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_success_response("smart", LlmProvider.OPENAI))
+
+        fast_broken = _make_client(LlmProvider.OLLAMA, available=True)
+        fast_broken.send_async = AsyncMock(return_value=_fail_response("ollama down", LlmProvider.OLLAMA))
+
+        fast_working = _make_client(LlmProvider.GROQ, available=True)
+        fast_working.send_async = AsyncMock(return_value=_success_response("groq ok", LlmProvider.GROQ))
+
+        # Open OLLAMA's circuit before creating the orchestrated client
+        cb.record_failure(LlmProvider.OLLAMA)
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast_broken, fast_working],
+            circuit_breaker=cb,
+        )
+
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=True)
+        response = await orchestrated.send_async(request)
+
+        assert response.success is True
+        assert response.content == "groq ok"
+        # OLLAMA should NOT have been called (circuit open)
+        fast_broken.send_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_fast_circuits_open_falls_back_to_smart(self):
+        """When all fast provider circuits are open, falls back to smart tier."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_success_response("smart fallback", LlmProvider.OPENAI))
+
+        fast1 = _make_client(LlmProvider.OLLAMA, available=True)
+        fast2 = _make_client(LlmProvider.GROQ, available=True)
+
+        # Open both fast provider circuits
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.GROQ)
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast1, fast2],
+            circuit_breaker=cb,
+        )
+
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=True)
+        response = await orchestrated.send_async(request)
+
+        assert response.success is True
+        assert response.content == "smart fallback"
+        fast1.send_async.assert_not_called()
+        fast2.send_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_smart_fallback_skips_open_circuit_fast_provider(self):
+        """When smart fails and falls back to fast, circuit-open providers are skipped."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_fail_response("smart failed", LlmProvider.OPENAI))
+
+        fast_broken = _make_client(LlmProvider.OLLAMA, available=True)
+        fast_broken.send_async = AsyncMock(return_value=_fail_response("ollama down", LlmProvider.OLLAMA))
+
+        fast_working = _make_client(LlmProvider.GROQ, available=True)
+        fast_working.send_async = AsyncMock(return_value=_success_response("groq fallback", LlmProvider.GROQ))
+
+        # Open OLLAMA's circuit
+        cb.record_failure(LlmProvider.OLLAMA)
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast_broken, fast_working],
+            circuit_breaker=cb,
+        )
+
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=False)
+        response = await orchestrated.send_async(request)
+
+        assert response.success is True
+        assert response.content == "groq fallback"
+        # OLLAMA should NOT have been called in fallback (circuit open)
+        fast_broken.send_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_in_fast_tier_records_to_circuit_breaker(self):
+        """Failures during fast tier racing are recorded in the circuit breaker."""
+        cb = ProviderCircuitBreaker(fail_threshold=2)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_success_response("smart", LlmProvider.OPENAI))
+
+        fast = _make_client(LlmProvider.OLLAMA, available=True)
+        fast.send_async = AsyncMock(return_value=_fail_response("ollama error", LlmProvider.OLLAMA))
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast],
+            circuit_breaker=cb,
+        )
+
+        # First request - fast fails, falls back to smart
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=True)
+        await orchestrated.send_async(request)
+
+        # After 1 failure, circuit should still be closed (threshold=2)
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+        # Second request - fast fails again
+        await orchestrated.send_async(request)
+
+        # After 2 failures, circuit should be open
+        assert cb.is_open(LlmProvider.OLLAMA) is True
+
+    @pytest.mark.asyncio
+    async def test_success_in_fast_tier_records_to_circuit_breaker(self):
+        """Successes during fast tier are recorded in the circuit breaker."""
+        cb = ProviderCircuitBreaker(fail_threshold=3)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        fast = _make_client(LlmProvider.OLLAMA, available=True)
+        fast.send_async = AsyncMock(return_value=_success_response("ok", LlmProvider.OLLAMA))
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast],
+            circuit_breaker=cb,
+        )
+
+        # Record 2 failures (one below threshold)
+        cb.record_failure(LlmProvider.OLLAMA)
+        cb.record_failure(LlmProvider.OLLAMA)
+
+        # A successful request should reset the failure count
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=True)
+        response = await orchestrated.send_async(request)
+
+        assert response.success is True
+        # Failure count should be reset, so one more failure should NOT open circuit
+        cb.record_failure(LlmProvider.OLLAMA)
+        assert cb.is_open(LlmProvider.OLLAMA) is False
+
+    @pytest.mark.asyncio
+    async def test_smart_tier_circuit_open_still_attempts(self):
+        """Smart tier is always attempted even with open circuit (last resort)."""
+        cb = ProviderCircuitBreaker(fail_threshold=1)
+
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_success_response("smart recovered", LlmProvider.OPENAI))
+
+        # Open smart provider's circuit
+        cb.record_failure(LlmProvider.OPENAI)
+        assert cb.is_open(LlmProvider.OPENAI) is True
+
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[],
+            circuit_breaker=cb,
+        )
+
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=False)
+        response = await orchestrated.send_async(request)
+
+        # Smart tier should still be attempted even with open circuit
+        assert response.success is True
+        smart.send_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_default_circuit_breaker_created_when_none_provided(self):
+        """OrchestratedLlmClient creates a default circuit breaker if none is provided."""
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        orchestrated = OrchestratedLlmClient(smart_client=smart, fast_clients=[])
+
+        assert orchestrated.circuit_breaker is not None
+        assert isinstance(orchestrated.circuit_breaker, ProviderCircuitBreaker)
+
+    @pytest.mark.asyncio
+    async def test_existing_tests_pass_with_default_circuit_breaker(self):
+        """Verify backward compatibility: existing behavior works with default circuit breaker."""
+        smart = _make_client(LlmProvider.OPENAI, available=True)
+        smart.send_async = AsyncMock(return_value=_success_response("result", LlmProvider.OPENAI))
+
+        fast = _make_client(LlmProvider.OLLAMA, available=True)
+        fast.send_async = AsyncMock(return_value=_success_response("fast result", LlmProvider.OLLAMA))
+
+        # No explicit circuit_breaker -- should use default
+        orchestrated = OrchestratedLlmClient(
+            smart_client=smart,
+            fast_clients=[fast],
+        )
+
+        request = LlmRequest(system_prompt="", user_message="test", use_fast_tier=True)
+        response = await orchestrated.send_async(request)
+
+        assert response.success is True
+        assert response.content == "fast result"


### PR DESCRIPTION
## Summary
- Adds `ProviderCircuitBreaker` class (`src/warden/llm/circuit_breaker.py`) that tracks failures per LLM provider at the orchestrator level
- Integrates circuit breaker into `OrchestratedLlmClient.send_async()` to skip providers with open circuits immediately, preventing cascading timeouts (previously 5 frames x 3 retries x 30s = 450s blocked)
- Smart tier is always attempted as last resort even when its circuit is open; fast tier providers with open circuits are skipped in both the parallel racing path and the smart-tier fallback path

Closes #127

## Details

**Circuit breaker states:**
- `CLOSED` - Provider is healthy, requests flow normally
- `OPEN` - Provider exceeded failure threshold (default: 3), requests skip immediately
- `HALF_OPEN` - After open duration (default: 5min), one probe request is allowed to test recovery

**Integration points in `orchestrated.py`:**
1. Fast tier parallel racing: filters out open-circuit providers before creating race tasks
2. Smart tier: logs warning but still attempts (last resort)
3. Smart-tier fallback to fast: skips open-circuit providers in the fallback loop
4. Records success/failure after every provider attempt to keep circuit state current

## Test plan
- [x] 10 unit tests for `ProviderCircuitBreaker` state machine (CLOSED->OPEN->HALF_OPEN->CLOSED, failure counting, success reset, independent providers, manual reset, helpers)
- [x] 8 integration tests for `OrchestratedLlmClient` with circuit breaker (skip open-circuit fast providers, all-circuits-open fallback to smart, smart fallback skips open circuits, failure/success recording, smart tier always attempted, backward compatibility)
- [x] All 35 existing LLM/orchestrated tests pass without modification (backward compatible)