### PR TITLE
feat(security): add HTTP security and CSRF protection detection

### DIFF
--- a/.warden/frames/security/_internal/csrf_check.py
+++ b/.warden/frames/security/_internal/csrf_check.py
@@ -1,0 +1,354 @@
+"""
+CSRF (Cross-Site Request Forgery) Protection Detection Check.
+
+Detects missing or disabled CSRF protection:
+- Django @csrf_exempt on POST routes
+- Missing CsrfViewMiddleware in Django
+- Flask without flask-wtf CSRFProtect
+- Express without csurf or equivalent CSRF middleware
+"""
+
+import re
+from typing import Any
+
+from warden.shared.infrastructure.logging import get_logger
+from warden.validation.domain.check import (
+    CheckFinding,
+    CheckResult,
+    CheckSeverity,
+    ValidationCheck,
+)
+from warden.validation.domain.frame import CodeFile
+
+logger = get_logger(__name__)
+
+
+class CSRFCheck(ValidationCheck):
+    """
+    Detects missing or disabled CSRF protection.
+
+    Patterns detected:
+    - Django @csrf_exempt decorator on views handling POST
+    - Missing django.middleware.csrf.CsrfViewMiddleware in MIDDLEWARE
+    - Flask applications without flask-wtf CSRFProtect
+    - Express applications without csurf or equivalent CSRF middleware
+
+    Severity: HIGH (can lead to unauthorized state-changing requests)
+    """
+
+    id = "csrf"
+    name = "CSRF Protection Detection"
+    description = "Detects missing or disabled CSRF protection"
+    severity = CheckSeverity.HIGH
+    version = "1.0.0"
+    author = "Warden Security Team"
+    enabled_by_default = True
+
+    # Django CSRF patterns
+    DJANGO_PATTERNS = [
+        # @csrf_exempt decorator
+        (
+            r"""@csrf_exempt""",
+            "Django @csrf_exempt disables CSRF protection on this view",
+        ),
+    ]
+
+    # Django settings patterns (file-level checks)
+    DJANGO_SETTINGS_PATTERNS = [
+        # MIDDLEWARE without CsrfViewMiddleware
+        (
+            r"""MIDDLEWARE\s*=\s*\[""",
+            "django_middleware_check",  # Special handler
+        ),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Initialize CSRF check."""
+        super().__init__(config)
+
+        # Pre-compile Django patterns
+        self._compiled_django_patterns = [
+            (re.compile(pattern_str), description)
+            for pattern_str, description in self.DJANGO_PATTERNS
+        ]
+
+        # Pre-compile detection helpers
+        self._csrf_exempt_pattern = re.compile(r"""@csrf_exempt""")
+        self._csrf_exempt_import_pattern = re.compile(
+            r"""from\s+django\.views\.decorators\.csrf\s+import\s+csrf_exempt"""
+        )
+        self._middleware_pattern = re.compile(r"""MIDDLEWARE\s*=\s*\[""")
+        self._csrf_middleware_pattern = re.compile(
+            r"""django\.middleware\.csrf\.CsrfViewMiddleware"""
+        )
+
+        # Flask patterns
+        self._flask_app_pattern = re.compile(
+            r"""Flask\s*\(\s*__name__\s*\)"""
+        )
+        self._flask_csrf_pattern = re.compile(
+            r"""CSRFProtect\s*\("""
+        )
+        self._flask_wtf_import_pattern = re.compile(
+            r"""from\s+flask_wtf\.csrf\s+import\s+CSRFProtect"""
+        )
+
+        # Express patterns
+        self._express_require_pattern = re.compile(
+            r"""require\s*\(\s*['"]express['"]\s*\)"""
+        )
+        self._express_import_pattern = re.compile(
+            r"""import\s+.*\s+from\s+['"]express['"]"""
+        )
+        self._csurf_pattern = re.compile(r"""csurf""")
+        self._csrf_middleware_js_pattern = re.compile(
+            r"""csrf|csrfProtection|csrfToken|_csrf"""
+        )
+
+    async def execute_async(self, code_file: CodeFile) -> CheckResult:
+        """Execute CSRF protection detection."""
+        findings: list[CheckFinding] = []
+
+        # Run language-appropriate checks
+        if code_file.language == "python":
+            findings.extend(self._check_django_csrf(code_file))
+            findings.extend(self._check_django_middleware(code_file))
+            findings.extend(self._check_flask_csrf(code_file))
+        elif code_file.language in ("javascript", "typescript"):
+            findings.extend(self._check_express_csrf(code_file))
+
+        return CheckResult(
+            check_id=self.id,
+            check_name=self.name,
+            passed=len(findings) == 0,
+            findings=findings,
+            metadata={
+                "language": code_file.language,
+            },
+        )
+
+    def _check_django_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for Django @csrf_exempt usage."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check if csrf_exempt is imported or used
+        if not self._csrf_exempt_pattern.search(content):
+            return findings
+
+        lines = content.split("\n")
+
+        for line_num, line in enumerate(lines, start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#"):
+                continue
+
+            # Detect @csrf_exempt decorator
+            if self._csrf_exempt_pattern.search(stripped):
+                # Look ahead to find the function name for better context
+                func_name = self._find_next_function(lines, line_num - 1)
+
+                suppression_matcher = self._get_suppression_matcher(code_file.path)
+                if suppression_matcher and suppression_matcher.is_suppressed(
+                    line=line_num,
+                    rule=self.id,
+                    file_path=str(code_file.path),
+                    code=content,
+                ):
+                    continue
+
+                message = "Django @csrf_exempt disables CSRF protection"
+                if func_name:
+                    message += f" on view '{func_name}'"
+
+                findings.append(
+                    CheckFinding(
+                        check_id=self.id,
+                        check_name=self.name,
+                        severity=CheckSeverity.HIGH,
+                        message=message,
+                        location=f"{code_file.path}:{line_num}",
+                        code_snippet=stripped,
+                        suggestion=(
+                            "Remove @csrf_exempt and handle CSRF properly:\n"
+                            "- For API endpoints: Use Django REST Framework with token authentication\n"
+                            "- For AJAX: Include CSRF token in request headers\n"
+                            "- For forms: Use {% csrf_token %} template tag"
+                        ),
+                        documentation_url="https://docs.djangoproject.com/en/stable/ref/csrf/",
+                    )
+                )
+
+        return findings
+
+    def _check_django_middleware(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CsrfViewMiddleware in Django settings."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check files that look like Django settings
+        if not self._middleware_pattern.search(content):
+            return findings
+
+        # Check if CsrfViewMiddleware is present
+        if self._csrf_middleware_pattern.search(content):
+            return findings
+
+        # Find the MIDDLEWARE line for location
+        for line_num, line in enumerate(content.split("\n"), start=1):
+            if self._middleware_pattern.search(line):
+                suppression_matcher = self._get_suppression_matcher(code_file.path)
+                if suppression_matcher and suppression_matcher.is_suppressed(
+                    line=line_num,
+                    rule=self.id,
+                    file_path=str(code_file.path),
+                    code=content,
+                ):
+                    continue
+
+                findings.append(
+                    CheckFinding(
+                        check_id=self.id,
+                        check_name=self.name,
+                        severity=CheckSeverity.CRITICAL,
+                        message="Django MIDDLEWARE is missing CsrfViewMiddleware (CSRF protection disabled)",
+                        location=f"{code_file.path}:{line_num}",
+                        code_snippet=line.strip(),
+                        suggestion=(
+                            "Add CsrfViewMiddleware to MIDDLEWARE:\n"
+                            "MIDDLEWARE = [\n"
+                            "    ...\n"
+                            "    'django.middleware.csrf.CsrfViewMiddleware',\n"
+                            "    ...\n"
+                            "]"
+                        ),
+                        documentation_url="https://docs.djangoproject.com/en/stable/ref/csrf/",
+                    )
+                )
+                break  # Only report once
+
+        return findings
+
+    def _check_flask_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CSRF protection in Flask applications."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check Flask applications
+        if not self._flask_app_pattern.search(content):
+            return findings
+
+        # Check if CSRFProtect is used
+        has_csrf = bool(
+            self._flask_csrf_pattern.search(content)
+            or self._flask_wtf_import_pattern.search(content)
+        )
+
+        if not has_csrf:
+            # Find the Flask app instantiation for location
+            for line_num, line in enumerate(content.split("\n"), start=1):
+                if self._flask_app_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.HIGH,
+                            message="Flask application without CSRF protection (flask-wtf CSRFProtect not found)",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=line.strip(),
+                            suggestion=(
+                                "Add CSRF protection with flask-wtf:\n"
+                                "from flask_wtf.csrf import CSRFProtect\n"
+                                "csrf = CSRFProtect(app)\n\n"
+                                "For API-only apps, consider token-based authentication instead."
+                            ),
+                            documentation_url="https://flask-wtf.readthedocs.io/en/stable/csrf.html",
+                        )
+                    )
+                    break  # Only report once
+
+        return findings
+
+    def _check_express_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CSRF protection in Express applications."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check Express applications
+        is_express = bool(
+            self._express_require_pattern.search(content)
+            or self._express_import_pattern.search(content)
+        )
+
+        if not is_express:
+            return findings
+
+        # Check if csurf or any CSRF middleware is used
+        has_csrf = bool(
+            self._csurf_pattern.search(content)
+            or self._csrf_middleware_js_pattern.search(content)
+        )
+
+        if not has_csrf:
+            # Check if app handles POST/PUT/DELETE (state-changing operations)
+            has_state_changing = bool(
+                re.search(r"""\.(post|put|delete|patch)\s*\(""", content)
+            )
+
+            if has_state_changing:
+                # Find the express import for location
+                for line_num, line in enumerate(content.split("\n"), start=1):
+                    if (
+                        self._express_require_pattern.search(line)
+                        or self._express_import_pattern.search(line)
+                    ):
+                        suppression_matcher = self._get_suppression_matcher(code_file.path)
+                        if suppression_matcher and suppression_matcher.is_suppressed(
+                            line=line_num,
+                            rule=self.id,
+                            file_path=str(code_file.path),
+                            code=content,
+                        ):
+                            continue
+
+                        findings.append(
+                            CheckFinding(
+                                check_id=self.id,
+                                check_name=self.name,
+                                severity=CheckSeverity.HIGH,
+                                message="Express application with state-changing routes but no CSRF protection",
+                                location=f"{code_file.path}:{line_num}",
+                                code_snippet=line.strip(),
+                                suggestion=(
+                                    "Add CSRF protection middleware:\n"
+                                    "const csrf = require('csurf');\n"
+                                    "app.use(csrf({ cookie: true }));\n\n"
+                                    "Or use a modern alternative like csrf-csrf or lusca.\n"
+                                    "For API-only apps, consider token-based authentication."
+                                ),
+                                documentation_url="https://owasp.org/www-community/attacks/csrf",
+                            )
+                        )
+                        break  # Only report once
+
+        return findings
+
+    def _find_next_function(self, lines: list[str], start_idx: int) -> str | None:
+        """Find the next function definition after a decorator."""
+        for i in range(start_idx + 1, min(start_idx + 5, len(lines))):
+            line = lines[i].strip()
+            match = re.match(r"""(?:def|async\s+def)\s+(\w+)\s*\(""", line)
+            if match:
+                return match.group(1)
+        return None

--- a/.warden/frames/security/_internal/http_security_check.py
+++ b/.warden/frames/security/_internal/http_security_check.py
@@ -1,0 +1,435 @@
+"""
+HTTP Security Misconfiguration Detection Check.
+
+Detects HTTP security misconfigurations:
+- Permissive CORS configurations (Express, Django, FastAPI)
+- Cookies without Secure, HttpOnly, SameSite flags
+- Missing helmet() middleware in Express applications
+"""
+
+import re
+from typing import Any
+
+from warden.shared.infrastructure.logging import get_logger
+from warden.validation.domain.check import (
+    CheckFinding,
+    CheckResult,
+    CheckSeverity,
+    ValidationCheck,
+)
+from warden.validation.domain.frame import CodeFile
+
+logger = get_logger(__name__)
+
+
+class HTTPSecurityCheck(ValidationCheck):
+    """
+    Detects HTTP security misconfigurations.
+
+    Patterns detected:
+    - cors({ origin: '*' }) in Express
+    - app.use(cors()) without configuration
+    - Django CORS_ALLOW_ALL_ORIGINS = True
+    - FastAPI allow_origins=["*"]
+    - Cookies without Secure, HttpOnly, SameSite flags
+    - Missing helmet() middleware in Express
+
+    Severity: HIGH (can lead to cross-origin attacks and data theft)
+    """
+
+    id = "http-security"
+    name = "HTTP Security Misconfiguration Detection"
+    description = "Detects CORS, cookie, and security header misconfigurations"
+    severity = CheckSeverity.HIGH
+    version = "1.0.0"
+    author = "Warden Security Team"
+    enabled_by_default = True
+
+    # CORS misconfiguration patterns
+    CORS_PATTERNS = [
+        # Express: cors({ origin: '*' }) or cors({origin: "*"})
+        (
+            r"""cors\(\s*\{[^}]*origin\s*:\s*['"][*]['"]""",
+            "CORS configured with wildcard origin (allows any domain)",
+        ),
+        # Express: app.use(cors()) with no arguments
+        (
+            r"""\.use\(\s*cors\(\s*\)\s*\)""",
+            "CORS middleware used without configuration (allows all origins by default)",
+        ),
+        # Django: CORS_ALLOW_ALL_ORIGINS = True
+        (
+            r"""CORS_ALLOW_ALL_ORIGINS\s*=\s*True""",
+            "Django CORS allows all origins",
+        ),
+        # Django legacy: CORS_ORIGIN_ALLOW_ALL = True
+        (
+            r"""CORS_ORIGIN_ALLOW_ALL\s*=\s*True""",
+            "Django CORS allows all origins (legacy setting)",
+        ),
+        # FastAPI: allow_origins=["*"]
+        (
+            r"""allow_origins\s*=\s*\[\s*['"][*]['"]\s*\]""",
+            "FastAPI CORS allows wildcard origin",
+        ),
+        # Flask-CORS: CORS(app, resources={r"/*": {"origins": "*"}})
+        (
+            r"""origins['"]\s*:\s*['"][*]['"]""",
+            "Flask CORS configured with wildcard origin",
+        ),
+        # Generic Access-Control-Allow-Origin: *
+        (
+            r"""Access-Control-Allow-Origin['"].*['"]\*['"]""",
+            "Access-Control-Allow-Origin header set to wildcard",
+        ),
+    ]
+
+    # Insecure cookie patterns
+    COOKIE_PATTERNS = [
+        # Express: res.cookie() without secure flag
+        (
+            r"""\.cookie\s*\([^)]*\)""",
+            "cookie_check",  # Special handler - needs deeper inspection
+        ),
+        # Python: set_cookie without secure/httponly
+        (
+            r"""set_cookie\s*\([^)]*\)""",
+            "set_cookie_check",  # Special handler
+        ),
+        # Django: SESSION_COOKIE_SECURE = False
+        (
+            r"""SESSION_COOKIE_SECURE\s*=\s*False""",
+            "Django session cookie not marked as Secure",
+        ),
+        # Django: CSRF_COOKIE_SECURE = False
+        (
+            r"""CSRF_COOKIE_SECURE\s*=\s*False""",
+            "Django CSRF cookie not marked as Secure",
+        ),
+        # Django: SESSION_COOKIE_HTTPONLY = False
+        (
+            r"""SESSION_COOKIE_HTTPONLY\s*=\s*False""",
+            "Django session cookie not marked as HttpOnly",
+        ),
+        # Django: CSRF_COOKIE_HTTPONLY = False
+        (
+            r"""CSRF_COOKIE_HTTPONLY\s*=\s*False""",
+            "Django CSRF cookie not marked as HttpOnly",
+        ),
+        # Django: SESSION_COOKIE_SAMESITE set to None or False
+        (
+            r"""SESSION_COOKIE_SAMESITE\s*=\s*(?:None|False|'None')""",
+            "Django session cookie SameSite not set or disabled",
+        ),
+    ]
+
+    # Missing security headers patterns
+    HEADER_PATTERNS = [
+        # Express app without helmet
+        (
+            r"""require\s*\(\s*['"]express['"]\s*\)""",
+            "express_helmet_check",  # Special handler - checks file for helmet usage
+        ),
+        # Express import without helmet
+        (
+            r"""import\s+.*\s+from\s+['"]express['"]""",
+            "express_helmet_check_esm",  # Special handler
+        ),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Initialize HTTP security check."""
+        super().__init__(config)
+
+        # Pre-compile CORS patterns
+        self._compiled_cors_patterns = [
+            (re.compile(pattern_str, re.IGNORECASE), description)
+            for pattern_str, description in self.CORS_PATTERNS
+        ]
+
+        # Pre-compile cookie patterns (non-special ones)
+        self._compiled_cookie_patterns = [
+            (re.compile(pattern_str), description)
+            for pattern_str, description in self.COOKIE_PATTERNS
+            if description not in ("cookie_check", "set_cookie_check")
+        ]
+
+        # Pre-compile special cookie patterns
+        self._cookie_call_pattern = re.compile(r"""\.cookie\s*\(""")
+        self._set_cookie_call_pattern = re.compile(r"""set_cookie\s*\(""")
+
+        # Pre-compile header patterns
+        self._express_require_pattern = re.compile(
+            r"""require\s*\(\s*['"]express['"]\s*\)"""
+        )
+        self._express_import_pattern = re.compile(
+            r"""import\s+.*\s+from\s+['"]express['"]"""
+        )
+        self._helmet_pattern = re.compile(r"""helmet\s*\(""")
+
+    async def execute_async(self, code_file: CodeFile) -> CheckResult:
+        """Execute HTTP security misconfiguration detection."""
+        findings: list[CheckFinding] = []
+
+        # Run all sub-checks
+        findings.extend(self._check_cors(code_file))
+        findings.extend(self._check_cookies(code_file))
+        findings.extend(self._check_missing_headers(code_file))
+
+        return CheckResult(
+            check_id=self.id,
+            check_name=self.name,
+            passed=len(findings) == 0,
+            findings=findings,
+            metadata={
+                "cors_patterns_checked": len(self.CORS_PATTERNS),
+                "cookie_patterns_checked": len(self.COOKIE_PATTERNS),
+            },
+        )
+
+    def _check_cors(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for CORS misconfigurations."""
+        findings: list[CheckFinding] = []
+
+        for line_num, line in enumerate(code_file.content.split("\n"), start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+
+            for compiled_pattern, description in self._compiled_cors_patterns:
+                if compiled_pattern.search(line):
+                    # Check suppression
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.HIGH,
+                            message=f"CORS misconfiguration: {description}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Restrict CORS to specific trusted origins:\n"
+                                "Express: cors({ origin: ['https://myapp.com'] })\n"
+                                "Django: CORS_ALLOWED_ORIGINS = ['https://myapp.com']\n"
+                                "FastAPI: allow_origins=['https://myapp.com']"
+                            ),
+                            documentation_url="https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny",
+                        )
+                    )
+
+        return findings
+
+    def _check_cookies(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for insecure cookie configurations."""
+        findings: list[CheckFinding] = []
+        lines = code_file.content.split("\n")
+
+        for line_num, line in enumerate(lines, start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+
+            # Check Django-style cookie settings
+            for compiled_pattern, description in self._compiled_cookie_patterns:
+                if compiled_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Insecure cookie configuration: {description}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Set secure cookie flags:\n"
+                                "Django: SESSION_COOKIE_SECURE = True, SESSION_COOKIE_HTTPONLY = True\n"
+                                "Express: res.cookie('name', 'val', { secure: true, httpOnly: true, sameSite: 'strict' })\n"
+                                "Flask: response.set_cookie('name', 'val', secure=True, httponly=True, samesite='Strict')"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+            # Check Express .cookie() calls for missing flags
+            if self._cookie_call_pattern.search(line):
+                cookie_context = self._get_multiline_context(lines, line_num - 1, max_lines=5)
+                missing_flags = self._check_express_cookie_flags(cookie_context)
+                if missing_flags:
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Cookie missing security flags: {', '.join(missing_flags)}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Add security flags to cookies:\n"
+                                "res.cookie('name', 'value', {\n"
+                                "  secure: true,\n"
+                                "  httpOnly: true,\n"
+                                "  sameSite: 'strict'\n"
+                                "})"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+            # Check Python set_cookie() calls for missing flags
+            if self._set_cookie_call_pattern.search(line):
+                cookie_context = self._get_multiline_context(lines, line_num - 1, max_lines=5)
+                missing_flags = self._check_python_cookie_flags(cookie_context)
+                if missing_flags:
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Cookie missing security flags: {', '.join(missing_flags)}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Add security flags to cookies:\n"
+                                "response.set_cookie('name', 'value', secure=True, httponly=True, samesite='Strict')"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+        return findings
+
+    def _check_missing_headers(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing security headers (helmet in Express)."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check JavaScript/TypeScript files
+        if code_file.language not in ("javascript", "typescript"):
+            return findings
+
+        # Check if this is an Express application
+        is_express = bool(
+            self._express_require_pattern.search(content)
+            or self._express_import_pattern.search(content)
+        )
+
+        if not is_express:
+            return findings
+
+        # Check if helmet is used
+        has_helmet = bool(self._helmet_pattern.search(content))
+
+        if not has_helmet:
+            # Find the express import/require line for location
+            for line_num, line in enumerate(content.split("\n"), start=1):
+                if self._express_require_pattern.search(line) or self._express_import_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message="Express application without helmet() middleware (missing security headers)",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=line.strip(),
+                            suggestion=(
+                                "Add helmet middleware for security headers:\n"
+                                "const helmet = require('helmet');\n"
+                                "app.use(helmet());\n\n"
+                                "Helmet sets headers like X-Content-Type-Options, "
+                                "X-Frame-Options, Strict-Transport-Security, etc."
+                            ),
+                            documentation_url="https://helmetjs.github.io/",
+                        )
+                    )
+                    break  # Only report once
+
+        return findings
+
+    def _get_multiline_context(
+        self, lines: list[str], start_idx: int, max_lines: int = 5
+    ) -> str:
+        """Get multiline context starting from a line index."""
+        end_idx = min(start_idx + max_lines, len(lines))
+        return "\n".join(lines[start_idx:end_idx])
+
+    def _check_express_cookie_flags(self, context: str) -> list[str]:
+        """Check if Express cookie call has required security flags."""
+        missing = []
+
+        # If the cookie call has an options object, check for flags
+        # Simple case: no options object at all (just name and value)
+        if "{" not in context:
+            return ["secure", "httpOnly", "sameSite"]
+
+        lower_context = context.lower()
+        if "secure" not in lower_context:
+            missing.append("secure")
+        if "httponly" not in lower_context:
+            missing.append("httpOnly")
+        if "samesite" not in lower_context:
+            missing.append("sameSite")
+
+        return missing
+
+    def _check_python_cookie_flags(self, context: str) -> list[str]:
+        """Check if Python set_cookie call has required security flags."""
+        missing = []
+        lower_context = context.lower()
+
+        if "secure" not in lower_context:
+            missing.append("secure")
+        if "httponly" not in lower_context:
+            missing.append("httponly")
+        if "samesite" not in lower_context:
+            missing.append("samesite")
+
+        return missing

--- a/.warden/frames/security/frame.py
+++ b/.warden/frames/security/frame.py
@@ -86,12 +86,14 @@ class SecurityFrame(ValidationFrame):
             sys.path.append(current_dir)
 
         try:
-            from _internal.sql_injection_check import SQLInjectionCheck
-            from _internal.xss_check import XSSCheck
-            from _internal.secrets_check import SecretsCheck
+            from _internal.csrf_check import CSRFCheck
             from _internal.hardcoded_password_check import (
                 HardcodedPasswordCheck,
             )
+            from _internal.http_security_check import HTTPSecurityCheck
+            from _internal.secrets_check import SecretsCheck
+            from _internal.sql_injection_check import SQLInjectionCheck
+            from _internal.xss_check import XSSCheck
         except ImportError:
             logger.error("Failed to import internal checks")
             return
@@ -101,6 +103,8 @@ class SecurityFrame(ValidationFrame):
         self.checks.register(XSSCheck(self.config.get("xss", {})))
         self.checks.register(SecretsCheck(self.config.get("secrets", {})))
         self.checks.register(HardcodedPasswordCheck(self.config.get("hardcoded_password", {})))
+        self.checks.register(HTTPSecurityCheck(self.config.get("http_security", {})))
+        self.checks.register(CSRFCheck(self.config.get("csrf", {})))
 
         logger.info(
             "builtin_checks_registered",

--- a/src/warden/validation/frames/security/_internal/csrf_check.py
+++ b/src/warden/validation/frames/security/_internal/csrf_check.py
@@ -1,0 +1,354 @@
+"""
+CSRF (Cross-Site Request Forgery) Protection Detection Check.
+
+Detects missing or disabled CSRF protection:
+- Django @csrf_exempt on POST routes
+- Missing CsrfViewMiddleware in Django
+- Flask without flask-wtf CSRFProtect
+- Express without csurf or equivalent CSRF middleware
+"""
+
+import re
+from typing import Any
+
+from warden.shared.infrastructure.logging import get_logger
+from warden.validation.domain.check import (
+    CheckFinding,
+    CheckResult,
+    CheckSeverity,
+    ValidationCheck,
+)
+from warden.validation.domain.frame import CodeFile
+
+logger = get_logger(__name__)
+
+
+class CSRFCheck(ValidationCheck):
+    """
+    Detects missing or disabled CSRF protection.
+
+    Patterns detected:
+    - Django @csrf_exempt decorator on views handling POST
+    - Missing django.middleware.csrf.CsrfViewMiddleware in MIDDLEWARE
+    - Flask applications without flask-wtf CSRFProtect
+    - Express applications without csurf or equivalent CSRF middleware
+
+    Severity: HIGH (can lead to unauthorized state-changing requests)
+    """
+
+    id = "csrf"
+    name = "CSRF Protection Detection"
+    description = "Detects missing or disabled CSRF protection"
+    severity = CheckSeverity.HIGH
+    version = "1.0.0"
+    author = "Warden Security Team"
+    enabled_by_default = True
+
+    # Django CSRF patterns
+    DJANGO_PATTERNS = [
+        # @csrf_exempt decorator
+        (
+            r"""@csrf_exempt""",
+            "Django @csrf_exempt disables CSRF protection on this view",
+        ),
+    ]
+
+    # Django settings patterns (file-level checks)
+    DJANGO_SETTINGS_PATTERNS = [
+        # MIDDLEWARE without CsrfViewMiddleware
+        (
+            r"""MIDDLEWARE\s*=\s*\[""",
+            "django_middleware_check",  # Special handler
+        ),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Initialize CSRF check."""
+        super().__init__(config)
+
+        # Pre-compile Django patterns
+        self._compiled_django_patterns = [
+            (re.compile(pattern_str), description)
+            for pattern_str, description in self.DJANGO_PATTERNS
+        ]
+
+        # Pre-compile detection helpers
+        self._csrf_exempt_pattern = re.compile(r"""@csrf_exempt""")
+        self._csrf_exempt_import_pattern = re.compile(
+            r"""from\s+django\.views\.decorators\.csrf\s+import\s+csrf_exempt"""
+        )
+        self._middleware_pattern = re.compile(r"""MIDDLEWARE\s*=\s*\[""")
+        self._csrf_middleware_pattern = re.compile(
+            r"""django\.middleware\.csrf\.CsrfViewMiddleware"""
+        )
+
+        # Flask patterns
+        self._flask_app_pattern = re.compile(
+            r"""Flask\s*\(\s*__name__\s*\)"""
+        )
+        self._flask_csrf_pattern = re.compile(
+            r"""CSRFProtect\s*\("""
+        )
+        self._flask_wtf_import_pattern = re.compile(
+            r"""from\s+flask_wtf\.csrf\s+import\s+CSRFProtect"""
+        )
+
+        # Express patterns
+        self._express_require_pattern = re.compile(
+            r"""require\s*\(\s*['"]express['"]\s*\)"""
+        )
+        self._express_import_pattern = re.compile(
+            r"""import\s+.*\s+from\s+['"]express['"]"""
+        )
+        self._csurf_pattern = re.compile(r"""csurf""")
+        self._csrf_middleware_js_pattern = re.compile(
+            r"""csrf|csrfProtection|csrfToken|_csrf"""
+        )
+
+    async def execute_async(self, code_file: CodeFile) -> CheckResult:
+        """Execute CSRF protection detection."""
+        findings: list[CheckFinding] = []
+
+        # Run language-appropriate checks
+        if code_file.language == "python":
+            findings.extend(self._check_django_csrf(code_file))
+            findings.extend(self._check_django_middleware(code_file))
+            findings.extend(self._check_flask_csrf(code_file))
+        elif code_file.language in ("javascript", "typescript"):
+            findings.extend(self._check_express_csrf(code_file))
+
+        return CheckResult(
+            check_id=self.id,
+            check_name=self.name,
+            passed=len(findings) == 0,
+            findings=findings,
+            metadata={
+                "language": code_file.language,
+            },
+        )
+
+    def _check_django_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for Django @csrf_exempt usage."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check if csrf_exempt is imported or used
+        if not self._csrf_exempt_pattern.search(content):
+            return findings
+
+        lines = content.split("\n")
+
+        for line_num, line in enumerate(lines, start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#"):
+                continue
+
+            # Detect @csrf_exempt decorator
+            if self._csrf_exempt_pattern.search(stripped):
+                # Look ahead to find the function name for better context
+                func_name = self._find_next_function(lines, line_num - 1)
+
+                suppression_matcher = self._get_suppression_matcher(code_file.path)
+                if suppression_matcher and suppression_matcher.is_suppressed(
+                    line=line_num,
+                    rule=self.id,
+                    file_path=str(code_file.path),
+                    code=content,
+                ):
+                    continue
+
+                message = "Django @csrf_exempt disables CSRF protection"
+                if func_name:
+                    message += f" on view '{func_name}'"
+
+                findings.append(
+                    CheckFinding(
+                        check_id=self.id,
+                        check_name=self.name,
+                        severity=CheckSeverity.HIGH,
+                        message=message,
+                        location=f"{code_file.path}:{line_num}",
+                        code_snippet=stripped,
+                        suggestion=(
+                            "Remove @csrf_exempt and handle CSRF properly:\n"
+                            "- For API endpoints: Use Django REST Framework with token authentication\n"
+                            "- For AJAX: Include CSRF token in request headers\n"
+                            "- For forms: Use {% csrf_token %} template tag"
+                        ),
+                        documentation_url="https://docs.djangoproject.com/en/stable/ref/csrf/",
+                    )
+                )
+
+        return findings
+
+    def _check_django_middleware(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CsrfViewMiddleware in Django settings."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check files that look like Django settings
+        if not self._middleware_pattern.search(content):
+            return findings
+
+        # Check if CsrfViewMiddleware is present
+        if self._csrf_middleware_pattern.search(content):
+            return findings
+
+        # Find the MIDDLEWARE line for location
+        for line_num, line in enumerate(content.split("\n"), start=1):
+            if self._middleware_pattern.search(line):
+                suppression_matcher = self._get_suppression_matcher(code_file.path)
+                if suppression_matcher and suppression_matcher.is_suppressed(
+                    line=line_num,
+                    rule=self.id,
+                    file_path=str(code_file.path),
+                    code=content,
+                ):
+                    continue
+
+                findings.append(
+                    CheckFinding(
+                        check_id=self.id,
+                        check_name=self.name,
+                        severity=CheckSeverity.CRITICAL,
+                        message="Django MIDDLEWARE is missing CsrfViewMiddleware (CSRF protection disabled)",
+                        location=f"{code_file.path}:{line_num}",
+                        code_snippet=line.strip(),
+                        suggestion=(
+                            "Add CsrfViewMiddleware to MIDDLEWARE:\n"
+                            "MIDDLEWARE = [\n"
+                            "    ...\n"
+                            "    'django.middleware.csrf.CsrfViewMiddleware',\n"
+                            "    ...\n"
+                            "]"
+                        ),
+                        documentation_url="https://docs.djangoproject.com/en/stable/ref/csrf/",
+                    )
+                )
+                break  # Only report once
+
+        return findings
+
+    def _check_flask_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CSRF protection in Flask applications."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check Flask applications
+        if not self._flask_app_pattern.search(content):
+            return findings
+
+        # Check if CSRFProtect is used
+        has_csrf = bool(
+            self._flask_csrf_pattern.search(content)
+            or self._flask_wtf_import_pattern.search(content)
+        )
+
+        if not has_csrf:
+            # Find the Flask app instantiation for location
+            for line_num, line in enumerate(content.split("\n"), start=1):
+                if self._flask_app_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.HIGH,
+                            message="Flask application without CSRF protection (flask-wtf CSRFProtect not found)",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=line.strip(),
+                            suggestion=(
+                                "Add CSRF protection with flask-wtf:\n"
+                                "from flask_wtf.csrf import CSRFProtect\n"
+                                "csrf = CSRFProtect(app)\n\n"
+                                "For API-only apps, consider token-based authentication instead."
+                            ),
+                            documentation_url="https://flask-wtf.readthedocs.io/en/stable/csrf.html",
+                        )
+                    )
+                    break  # Only report once
+
+        return findings
+
+    def _check_express_csrf(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing CSRF protection in Express applications."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check Express applications
+        is_express = bool(
+            self._express_require_pattern.search(content)
+            or self._express_import_pattern.search(content)
+        )
+
+        if not is_express:
+            return findings
+
+        # Check if csurf or any CSRF middleware is used
+        has_csrf = bool(
+            self._csurf_pattern.search(content)
+            or self._csrf_middleware_js_pattern.search(content)
+        )
+
+        if not has_csrf:
+            # Check if app handles POST/PUT/DELETE (state-changing operations)
+            has_state_changing = bool(
+                re.search(r"""\.(post|put|delete|patch)\s*\(""", content)
+            )
+
+            if has_state_changing:
+                # Find the express import for location
+                for line_num, line in enumerate(content.split("\n"), start=1):
+                    if (
+                        self._express_require_pattern.search(line)
+                        or self._express_import_pattern.search(line)
+                    ):
+                        suppression_matcher = self._get_suppression_matcher(code_file.path)
+                        if suppression_matcher and suppression_matcher.is_suppressed(
+                            line=line_num,
+                            rule=self.id,
+                            file_path=str(code_file.path),
+                            code=content,
+                        ):
+                            continue
+
+                        findings.append(
+                            CheckFinding(
+                                check_id=self.id,
+                                check_name=self.name,
+                                severity=CheckSeverity.HIGH,
+                                message="Express application with state-changing routes but no CSRF protection",
+                                location=f"{code_file.path}:{line_num}",
+                                code_snippet=line.strip(),
+                                suggestion=(
+                                    "Add CSRF protection middleware:\n"
+                                    "const csrf = require('csurf');\n"
+                                    "app.use(csrf({ cookie: true }));\n\n"
+                                    "Or use a modern alternative like csrf-csrf or lusca.\n"
+                                    "For API-only apps, consider token-based authentication."
+                                ),
+                                documentation_url="https://owasp.org/www-community/attacks/csrf",
+                            )
+                        )
+                        break  # Only report once
+
+        return findings
+
+    def _find_next_function(self, lines: list[str], start_idx: int) -> str | None:
+        """Find the next function definition after a decorator."""
+        for i in range(start_idx + 1, min(start_idx + 5, len(lines))):
+            line = lines[i].strip()
+            match = re.match(r"""(?:def|async\s+def)\s+(\w+)\s*\(""", line)
+            if match:
+                return match.group(1)
+        return None

--- a/src/warden/validation/frames/security/_internal/http_security_check.py
+++ b/src/warden/validation/frames/security/_internal/http_security_check.py
@@ -1,0 +1,435 @@
+"""
+HTTP Security Misconfiguration Detection Check.
+
+Detects HTTP security misconfigurations:
+- Permissive CORS configurations (Express, Django, FastAPI)
+- Cookies without Secure, HttpOnly, SameSite flags
+- Missing helmet() middleware in Express applications
+"""
+
+import re
+from typing import Any
+
+from warden.shared.infrastructure.logging import get_logger
+from warden.validation.domain.check import (
+    CheckFinding,
+    CheckResult,
+    CheckSeverity,
+    ValidationCheck,
+)
+from warden.validation.domain.frame import CodeFile
+
+logger = get_logger(__name__)
+
+
+class HTTPSecurityCheck(ValidationCheck):
+    """
+    Detects HTTP security misconfigurations.
+
+    Patterns detected:
+    - cors({ origin: '*' }) in Express
+    - app.use(cors()) without configuration
+    - Django CORS_ALLOW_ALL_ORIGINS = True
+    - FastAPI allow_origins=["*"]
+    - Cookies without Secure, HttpOnly, SameSite flags
+    - Missing helmet() middleware in Express
+
+    Severity: HIGH (can lead to cross-origin attacks and data theft)
+    """
+
+    id = "http-security"
+    name = "HTTP Security Misconfiguration Detection"
+    description = "Detects CORS, cookie, and security header misconfigurations"
+    severity = CheckSeverity.HIGH
+    version = "1.0.0"
+    author = "Warden Security Team"
+    enabled_by_default = True
+
+    # CORS misconfiguration patterns
+    CORS_PATTERNS = [
+        # Express: cors({ origin: '*' }) or cors({origin: "*"})
+        (
+            r"""cors\(\s*\{[^}]*origin\s*:\s*['"][*]['"]""",
+            "CORS configured with wildcard origin (allows any domain)",
+        ),
+        # Express: app.use(cors()) with no arguments
+        (
+            r"""\.use\(\s*cors\(\s*\)\s*\)""",
+            "CORS middleware used without configuration (allows all origins by default)",
+        ),
+        # Django: CORS_ALLOW_ALL_ORIGINS = True
+        (
+            r"""CORS_ALLOW_ALL_ORIGINS\s*=\s*True""",
+            "Django CORS allows all origins",
+        ),
+        # Django legacy: CORS_ORIGIN_ALLOW_ALL = True
+        (
+            r"""CORS_ORIGIN_ALLOW_ALL\s*=\s*True""",
+            "Django CORS allows all origins (legacy setting)",
+        ),
+        # FastAPI: allow_origins=["*"]
+        (
+            r"""allow_origins\s*=\s*\[\s*['"][*]['"]\s*\]""",
+            "FastAPI CORS allows wildcard origin",
+        ),
+        # Flask-CORS: CORS(app, resources={r"/*": {"origins": "*"}})
+        (
+            r"""origins['"]\s*:\s*['"][*]['"]""",
+            "Flask CORS configured with wildcard origin",
+        ),
+        # Generic Access-Control-Allow-Origin: *
+        (
+            r"""Access-Control-Allow-Origin['"].*['"]\*['"]""",
+            "Access-Control-Allow-Origin header set to wildcard",
+        ),
+    ]
+
+    # Insecure cookie patterns
+    COOKIE_PATTERNS = [
+        # Express: res.cookie() without secure flag
+        (
+            r"""\.cookie\s*\([^)]*\)""",
+            "cookie_check",  # Special handler - needs deeper inspection
+        ),
+        # Python: set_cookie without secure/httponly
+        (
+            r"""set_cookie\s*\([^)]*\)""",
+            "set_cookie_check",  # Special handler
+        ),
+        # Django: SESSION_COOKIE_SECURE = False
+        (
+            r"""SESSION_COOKIE_SECURE\s*=\s*False""",
+            "Django session cookie not marked as Secure",
+        ),
+        # Django: CSRF_COOKIE_SECURE = False
+        (
+            r"""CSRF_COOKIE_SECURE\s*=\s*False""",
+            "Django CSRF cookie not marked as Secure",
+        ),
+        # Django: SESSION_COOKIE_HTTPONLY = False
+        (
+            r"""SESSION_COOKIE_HTTPONLY\s*=\s*False""",
+            "Django session cookie not marked as HttpOnly",
+        ),
+        # Django: CSRF_COOKIE_HTTPONLY = False
+        (
+            r"""CSRF_COOKIE_HTTPONLY\s*=\s*False""",
+            "Django CSRF cookie not marked as HttpOnly",
+        ),
+        # Django: SESSION_COOKIE_SAMESITE set to None or False
+        (
+            r"""SESSION_COOKIE_SAMESITE\s*=\s*(?:None|False|'None')""",
+            "Django session cookie SameSite not set or disabled",
+        ),
+    ]
+
+    # Missing security headers patterns
+    HEADER_PATTERNS = [
+        # Express app without helmet
+        (
+            r"""require\s*\(\s*['"]express['"]\s*\)""",
+            "express_helmet_check",  # Special handler - checks file for helmet usage
+        ),
+        # Express import without helmet
+        (
+            r"""import\s+.*\s+from\s+['"]express['"]""",
+            "express_helmet_check_esm",  # Special handler
+        ),
+    ]
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Initialize HTTP security check."""
+        super().__init__(config)
+
+        # Pre-compile CORS patterns
+        self._compiled_cors_patterns = [
+            (re.compile(pattern_str, re.IGNORECASE), description)
+            for pattern_str, description in self.CORS_PATTERNS
+        ]
+
+        # Pre-compile cookie patterns (non-special ones)
+        self._compiled_cookie_patterns = [
+            (re.compile(pattern_str), description)
+            for pattern_str, description in self.COOKIE_PATTERNS
+            if description not in ("cookie_check", "set_cookie_check")
+        ]
+
+        # Pre-compile special cookie patterns
+        self._cookie_call_pattern = re.compile(r"""\.cookie\s*\(""")
+        self._set_cookie_call_pattern = re.compile(r"""set_cookie\s*\(""")
+
+        # Pre-compile header patterns
+        self._express_require_pattern = re.compile(
+            r"""require\s*\(\s*['"]express['"]\s*\)"""
+        )
+        self._express_import_pattern = re.compile(
+            r"""import\s+.*\s+from\s+['"]express['"]"""
+        )
+        self._helmet_pattern = re.compile(r"""helmet\s*\(""")
+
+    async def execute_async(self, code_file: CodeFile) -> CheckResult:
+        """Execute HTTP security misconfiguration detection."""
+        findings: list[CheckFinding] = []
+
+        # Run all sub-checks
+        findings.extend(self._check_cors(code_file))
+        findings.extend(self._check_cookies(code_file))
+        findings.extend(self._check_missing_headers(code_file))
+
+        return CheckResult(
+            check_id=self.id,
+            check_name=self.name,
+            passed=len(findings) == 0,
+            findings=findings,
+            metadata={
+                "cors_patterns_checked": len(self.CORS_PATTERNS),
+                "cookie_patterns_checked": len(self.COOKIE_PATTERNS),
+            },
+        )
+
+    def _check_cors(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for CORS misconfigurations."""
+        findings: list[CheckFinding] = []
+
+        for line_num, line in enumerate(code_file.content.split("\n"), start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+
+            for compiled_pattern, description in self._compiled_cors_patterns:
+                if compiled_pattern.search(line):
+                    # Check suppression
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.HIGH,
+                            message=f"CORS misconfiguration: {description}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Restrict CORS to specific trusted origins:\n"
+                                "Express: cors({ origin: ['https://myapp.com'] })\n"
+                                "Django: CORS_ALLOWED_ORIGINS = ['https://myapp.com']\n"
+                                "FastAPI: allow_origins=['https://myapp.com']"
+                            ),
+                            documentation_url="https://owasp.org/www-community/attacks/CORS_OriginHeaderScrutiny",
+                        )
+                    )
+
+        return findings
+
+    def _check_cookies(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for insecure cookie configurations."""
+        findings: list[CheckFinding] = []
+        lines = code_file.content.split("\n")
+
+        for line_num, line in enumerate(lines, start=1):
+            stripped = line.strip()
+
+            # Skip comments
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+
+            # Check Django-style cookie settings
+            for compiled_pattern, description in self._compiled_cookie_patterns:
+                if compiled_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Insecure cookie configuration: {description}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Set secure cookie flags:\n"
+                                "Django: SESSION_COOKIE_SECURE = True, SESSION_COOKIE_HTTPONLY = True\n"
+                                "Express: res.cookie('name', 'val', { secure: true, httpOnly: true, sameSite: 'strict' })\n"
+                                "Flask: response.set_cookie('name', 'val', secure=True, httponly=True, samesite='Strict')"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+            # Check Express .cookie() calls for missing flags
+            if self._cookie_call_pattern.search(line):
+                cookie_context = self._get_multiline_context(lines, line_num - 1, max_lines=5)
+                missing_flags = self._check_express_cookie_flags(cookie_context)
+                if missing_flags:
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Cookie missing security flags: {', '.join(missing_flags)}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Add security flags to cookies:\n"
+                                "res.cookie('name', 'value', {\n"
+                                "  secure: true,\n"
+                                "  httpOnly: true,\n"
+                                "  sameSite: 'strict'\n"
+                                "})"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+            # Check Python set_cookie() calls for missing flags
+            if self._set_cookie_call_pattern.search(line):
+                cookie_context = self._get_multiline_context(lines, line_num - 1, max_lines=5)
+                missing_flags = self._check_python_cookie_flags(cookie_context)
+                if missing_flags:
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message=f"Cookie missing security flags: {', '.join(missing_flags)}",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=stripped,
+                            suggestion=(
+                                "Add security flags to cookies:\n"
+                                "response.set_cookie('name', 'value', secure=True, httponly=True, samesite='Strict')"
+                            ),
+                            documentation_url="https://owasp.org/www-community/controls/SecureCookieAttribute",
+                        )
+                    )
+
+        return findings
+
+    def _check_missing_headers(self, code_file: CodeFile) -> list[CheckFinding]:
+        """Check for missing security headers (helmet in Express)."""
+        findings: list[CheckFinding] = []
+        content = code_file.content
+
+        # Only check JavaScript/TypeScript files
+        if code_file.language not in ("javascript", "typescript"):
+            return findings
+
+        # Check if this is an Express application
+        is_express = bool(
+            self._express_require_pattern.search(content)
+            or self._express_import_pattern.search(content)
+        )
+
+        if not is_express:
+            return findings
+
+        # Check if helmet is used
+        has_helmet = bool(self._helmet_pattern.search(content))
+
+        if not has_helmet:
+            # Find the express import/require line for location
+            for line_num, line in enumerate(content.split("\n"), start=1):
+                if self._express_require_pattern.search(line) or self._express_import_pattern.search(line):
+                    suppression_matcher = self._get_suppression_matcher(code_file.path)
+                    if suppression_matcher and suppression_matcher.is_suppressed(
+                        line=line_num,
+                        rule=self.id,
+                        file_path=str(code_file.path),
+                        code=code_file.content,
+                    ):
+                        continue
+
+                    findings.append(
+                        CheckFinding(
+                            check_id=self.id,
+                            check_name=self.name,
+                            severity=CheckSeverity.MEDIUM,
+                            message="Express application without helmet() middleware (missing security headers)",
+                            location=f"{code_file.path}:{line_num}",
+                            code_snippet=line.strip(),
+                            suggestion=(
+                                "Add helmet middleware for security headers:\n"
+                                "const helmet = require('helmet');\n"
+                                "app.use(helmet());\n\n"
+                                "Helmet sets headers like X-Content-Type-Options, "
+                                "X-Frame-Options, Strict-Transport-Security, etc."
+                            ),
+                            documentation_url="https://helmetjs.github.io/",
+                        )
+                    )
+                    break  # Only report once
+
+        return findings
+
+    def _get_multiline_context(
+        self, lines: list[str], start_idx: int, max_lines: int = 5
+    ) -> str:
+        """Get multiline context starting from a line index."""
+        end_idx = min(start_idx + max_lines, len(lines))
+        return "\n".join(lines[start_idx:end_idx])
+
+    def _check_express_cookie_flags(self, context: str) -> list[str]:
+        """Check if Express cookie call has required security flags."""
+        missing = []
+
+        # If the cookie call has an options object, check for flags
+        # Simple case: no options object at all (just name and value)
+        if "{" not in context:
+            return ["secure", "httpOnly", "sameSite"]
+
+        lower_context = context.lower()
+        if "secure" not in lower_context:
+            missing.append("secure")
+        if "httponly" not in lower_context:
+            missing.append("httpOnly")
+        if "samesite" not in lower_context:
+            missing.append("sameSite")
+
+        return missing
+
+    def _check_python_cookie_flags(self, context: str) -> list[str]:
+        """Check if Python set_cookie call has required security flags."""
+        missing = []
+        lower_context = context.lower()
+
+        if "secure" not in lower_context:
+            missing.append("secure")
+        if "httponly" not in lower_context:
+            missing.append("httponly")
+        if "samesite" not in lower_context:
+            missing.append("samesite")
+
+        return missing

--- a/src/warden/validation/frames/security/frame.py
+++ b/src/warden/validation/frames/security/frame.py
@@ -105,9 +105,11 @@ class SecurityFrame(ValidationFrame, BatchExecutable, TaintAware, CodeGraphAware
             sys.path.append(current_dir)
 
         try:
+            from _internal.csrf_check import CSRFCheck
             from _internal.hardcoded_password_check import (
                 HardcodedPasswordCheck,
             )
+            from _internal.http_security_check import HTTPSecurityCheck
             from _internal.secrets_check import SecretsCheck
             from _internal.sql_injection_check import SQLInjectionCheck
             from _internal.xss_check import XSSCheck
@@ -120,6 +122,8 @@ class SecurityFrame(ValidationFrame, BatchExecutable, TaintAware, CodeGraphAware
         self.checks.register(XSSCheck(self.config.get("xss", {})))
         self.checks.register(SecretsCheck(self.config.get("secrets", {})))
         self.checks.register(HardcodedPasswordCheck(self.config.get("hardcoded_password", {})))
+        self.checks.register(HTTPSecurityCheck(self.config.get("http_security", {})))
+        self.checks.register(CSRFCheck(self.config.get("csrf", {})))
 
         logger.info(
             "builtin_checks_registered",

--- a/tests/validation/frames/security/test_csrf_check.py
+++ b/tests/validation/frames/security/test_csrf_check.py
@@ -1,0 +1,430 @@
+"""
+Tests for CSRFCheck.
+
+Tests CSRF protection detection:
+- Django @csrf_exempt usage
+- Missing CsrfViewMiddleware in Django MIDDLEWARE
+- Flask without flask-wtf CSRFProtect
+- Express without csurf or equivalent
+"""
+
+import pytest
+from warden.validation.domain.frame import CodeFile
+from warden.validation.frames.security._internal.csrf_check import CSRFCheck
+
+
+# ============================================================================
+# Django CSRF Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_django_csrf_exempt():
+    """Test detection of @csrf_exempt decorator."""
+    code = """
+from django.views.decorators.csrf import csrf_exempt
+from django.http import JsonResponse
+
+@csrf_exempt
+def webhook_handler(request):
+    if request.method == 'POST':
+        data = request.body
+        return JsonResponse({'status': 'ok'})
+"""
+
+    code_file = CodeFile(path="views.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    assert any("csrf_exempt" in f.message.lower() for f in result.findings)
+
+
+@pytest.mark.asyncio
+async def test_detect_django_csrf_exempt_with_function_name():
+    """Test that @csrf_exempt finding includes function name."""
+    code = """
+from django.views.decorators.csrf import csrf_exempt
+
+@csrf_exempt
+def payment_process(request):
+    return JsonResponse({'status': 'ok'})
+"""
+
+    code_file = CodeFile(path="views.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    # Should include function name in message
+    assert any("payment_process" in f.message for f in result.findings)
+
+
+@pytest.mark.asyncio
+async def test_detect_django_missing_csrf_middleware():
+    """Test detection of missing CsrfViewMiddleware in MIDDLEWARE."""
+    code = """
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    assert any("CsrfViewMiddleware" in f.message for f in result.findings)
+    # Missing middleware should be CRITICAL
+    assert any(f.severity.value == "critical" for f in result.findings)
+
+
+@pytest.mark.asyncio
+async def test_pass_django_with_csrf_middleware():
+    """Test that Django settings with CsrfViewMiddleware passes."""
+    code = """
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+]
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    # Should not detect missing middleware
+    middleware_findings = [f for f in result.findings if "CsrfViewMiddleware" in f.message]
+    assert len(middleware_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_csrf_exempt_in_comments():
+    """Test that @csrf_exempt in comments is skipped."""
+    code = """
+# @csrf_exempt  -- don't use this!
+# from django.views.decorators.csrf import csrf_exempt
+
+def my_view(request):
+    return JsonResponse({'status': 'ok'})
+"""
+
+    code_file = CodeFile(path="views.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_multiple_csrf_exempt_views():
+    """Test detection of multiple @csrf_exempt decorators."""
+    code = """
+from django.views.decorators.csrf import csrf_exempt
+
+@csrf_exempt
+def api_webhook(request):
+    return JsonResponse({'status': 'ok'})
+
+@csrf_exempt
+def api_callback(request):
+    return JsonResponse({'status': 'ok'})
+"""
+
+    code_file = CodeFile(path="views.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    csrf_exempt_findings = [f for f in result.findings if "csrf_exempt" in f.message.lower()]
+    assert len(csrf_exempt_findings) >= 2
+
+
+# ============================================================================
+# Flask CSRF Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_flask_without_csrf():
+    """Test detection of Flask app without CSRFProtect."""
+    code = """
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/submit', methods=['POST'])
+def submit():
+    return 'OK'
+"""
+
+    code_file = CodeFile(path="app.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    assert any("flask" in f.message.lower() and "csrf" in f.message.lower() for f in result.findings)
+
+
+@pytest.mark.asyncio
+async def test_pass_flask_with_csrf_protect():
+    """Test that Flask app with CSRFProtect passes."""
+    code = """
+from flask import Flask
+from flask_wtf.csrf import CSRFProtect
+
+app = Flask(__name__)
+csrf = CSRFProtect(app)
+
+@app.route('/submit', methods=['POST'])
+def submit():
+    return 'OK'
+"""
+
+    code_file = CodeFile(path="app.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    # No Flask CSRF findings
+    flask_csrf_findings = [f for f in result.findings if "flask" in f.message.lower()]
+    assert len(flask_csrf_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_pass_flask_with_csrf_import():
+    """Test that Flask app with CSRFProtect import passes."""
+    code = """
+from flask import Flask
+from flask_wtf.csrf import CSRFProtect
+
+app = Flask(__name__)
+
+# CSRFProtect initialized elsewhere
+"""
+
+    code_file = CodeFile(path="app.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    flask_csrf_findings = [f for f in result.findings if "flask" in f.message.lower()]
+    assert len(flask_csrf_findings) == 0
+
+
+# ============================================================================
+# Express CSRF Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_express_without_csrf():
+    """Test detection of Express app without CSRF protection."""
+    code = """
+const express = require('express');
+const app = express();
+
+app.post('/api/transfer', (req, res) => {
+    // Transfer money
+    res.json({ success: true });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    assert any("csrf" in f.message.lower() for f in result.findings)
+
+
+@pytest.mark.asyncio
+async def test_pass_express_with_csurf():
+    """Test that Express app with csurf passes."""
+    code = """
+const express = require('express');
+const csurf = require('csurf');
+const app = express();
+
+app.use(csurf({ cookie: true }));
+
+app.post('/api/transfer', (req, res) => {
+    res.json({ success: true });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_pass_express_with_csrf_token():
+    """Test that Express app with csrfToken usage passes."""
+    code = """
+const express = require('express');
+const app = express();
+
+// Custom CSRF middleware
+app.use((req, res, next) => {
+    const csrfToken = req.headers['x-csrf-token'];
+    if (req.method === 'POST' && !csrfToken) {
+        return res.status(403).json({ error: 'Missing CSRF token' });
+    }
+    next();
+});
+
+app.post('/api/data', (req, res) => {
+    res.json({ success: true });
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    # Should pass - has CSRF token handling
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+async def test_pass_express_get_only():
+    """Test that Express app with only GET routes passes (no state change)."""
+    code = """
+const express = require('express');
+const app = express();
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    # No CSRF findings for GET-only apps
+    csrf_findings = [f for f in result.findings if "csrf" in f.message.lower()]
+    assert len(csrf_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_express_esm_without_csrf():
+    """Test detection of Express ESM app without CSRF."""
+    code = """
+import express from 'express';
+const app = express();
+
+app.put('/api/users/:id', (req, res) => {
+    res.json({ updated: true });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.mjs", content=code, language="javascript")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    csrf_findings = [f for f in result.findings if "csrf" in f.message.lower()]
+    assert len(csrf_findings) >= 1
+
+
+# ============================================================================
+# Edge Cases
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_clean_code_passes():
+    """Test that clean non-web code passes."""
+    code = """
+def calculate(a, b):
+    return a + b
+
+result = calculate(1, 2)
+print(result)
+"""
+
+    code_file = CodeFile(path="utils.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_check_metadata():
+    """Test that check has correct metadata."""
+    check = CSRFCheck()
+
+    assert check.id == "csrf"
+    assert check.name == "CSRF Protection Detection"
+    assert check.severity.value == "high"
+    assert check.enabled_by_default is True
+
+
+@pytest.mark.asyncio
+async def test_non_python_non_js_passes():
+    """Test that non-Python/non-JS files are not checked."""
+    code = """
+package main
+
+import "net/http"
+
+func main() {
+    http.HandleFunc("/api/data", handler)
+    http.ListenAndServe(":8080", nil)
+}
+"""
+
+    code_file = CodeFile(path="main.go", content=code, language="go")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_django_csrf_exempt_async_view():
+    """Test detection of @csrf_exempt on async Django view."""
+    code = """
+from django.views.decorators.csrf import csrf_exempt
+
+@csrf_exempt
+async def async_webhook(request):
+    if request.method == 'POST':
+        return JsonResponse({'status': 'ok'})
+"""
+
+    code_file = CodeFile(path="views.py", content=code, language="python")
+    check = CSRFCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    # Should detect the async function name
+    assert any("async_webhook" in f.message for f in result.findings)

--- a/tests/validation/frames/security/test_http_security_check.py
+++ b/tests/validation/frames/security/test_http_security_check.py
@@ -1,0 +1,453 @@
+"""
+Tests for HTTPSecurityCheck.
+
+Tests HTTP security misconfiguration detection:
+- CORS wildcard/permissive configurations
+- Insecure cookie settings
+- Missing helmet middleware
+"""
+
+import pytest
+from warden.validation.domain.frame import CodeFile
+from warden.validation.frames.security._internal.http_security_check import (
+    HTTPSecurityCheck,
+)
+
+
+# ============================================================================
+# CORS Detection Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_express_cors_wildcard_origin():
+    """Test detection of cors({ origin: '*' }) in Express."""
+    code = """
+const express = require('express');
+const cors = require('cors');
+const app = express();
+
+app.use(cors({ origin: '*' }));
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    assert len(result.findings) >= 1
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) >= 1
+    assert "wildcard" in cors_findings[0].message.lower()
+
+
+@pytest.mark.asyncio
+async def test_detect_express_cors_no_config():
+    """Test detection of app.use(cors()) without configuration."""
+    code = """
+const express = require('express');
+const cors = require('cors');
+const app = express();
+
+app.use(cors());
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) >= 1
+    assert "without configuration" in cors_findings[0].message
+
+
+@pytest.mark.asyncio
+async def test_detect_django_cors_allow_all():
+    """Test detection of CORS_ALLOW_ALL_ORIGINS = True in Django."""
+    code = """
+# Django settings
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'corsheaders',
+]
+
+CORS_ALLOW_ALL_ORIGINS = True
+
+MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+]
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) >= 1
+    assert "all origins" in cors_findings[0].message.lower()
+
+
+@pytest.mark.asyncio
+async def test_detect_django_cors_legacy_setting():
+    """Test detection of CORS_ORIGIN_ALLOW_ALL = True (legacy)."""
+    code = """
+CORS_ORIGIN_ALLOW_ALL = True
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_detect_fastapi_cors_wildcard():
+    """Test detection of allow_origins=["*"] in FastAPI."""
+    code = """
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+"""
+
+    code_file = CodeFile(path="main.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) >= 1
+    assert "wildcard" in cors_findings[0].message.lower()
+
+
+@pytest.mark.asyncio
+async def test_pass_cors_specific_origins():
+    """Test that specific CORS origins pass validation."""
+    code = """
+const express = require('express');
+const cors = require('cors');
+const app = express();
+
+app.use(cors({ origin: ['https://myapp.com', 'https://admin.myapp.com'] }));
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    # Should pass - no CORS findings (may have helmet findings)
+    cors_findings = [f for f in result.findings if "CORS" in f.message]
+    assert len(cors_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_cors_in_comments():
+    """Test that CORS patterns in comments are skipped."""
+    code = """
+# CORS_ALLOW_ALL_ORIGINS = True  # Don't do this!
+// app.use(cors());  -- bad practice
+"""
+
+    code_file = CodeFile(path="notes.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+# ============================================================================
+# Cookie Security Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_django_session_cookie_insecure():
+    """Test detection of SESSION_COOKIE_SECURE = False."""
+    code = """
+SESSION_COOKIE_SECURE = False
+SESSION_COOKIE_HTTPONLY = False
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cookie_findings = [f for f in result.findings if "cookie" in f.message.lower()]
+    assert len(cookie_findings) >= 2
+
+
+@pytest.mark.asyncio
+async def test_detect_express_cookie_missing_flags():
+    """Test detection of Express cookie without security flags."""
+    code = """
+const express = require('express');
+const app = express();
+
+app.get('/login', (req, res) => {
+    res.cookie('session', 'abc123');
+    res.send('OK');
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cookie_findings = [f for f in result.findings if "cookie" in f.message.lower() or "Cookie" in f.message]
+    assert len(cookie_findings) >= 1
+    # Should detect missing secure, httpOnly, sameSite
+    assert any("secure" in f.message.lower() for f in cookie_findings)
+
+
+@pytest.mark.asyncio
+async def test_pass_express_cookie_with_flags():
+    """Test that Express cookie with all security flags passes."""
+    code = """
+const express = require('express');
+const helmet = require('helmet');
+const app = express();
+app.use(helmet());
+
+app.get('/login', (req, res) => {
+    res.cookie('session', 'abc123', {
+        secure: true,
+        httpOnly: true,
+        sameSite: 'strict'
+    });
+    res.send('OK');
+});
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    # Cookie findings should be empty (all flags present)
+    cookie_findings = [f for f in result.findings if "Cookie" in f.message or "cookie" in f.message.lower()]
+    assert len(cookie_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_python_set_cookie_missing_flags():
+    """Test detection of set_cookie without security flags."""
+    code = """
+from flask import Flask, make_response
+
+app = Flask(__name__)
+
+@app.route('/login')
+def login():
+    response = make_response('OK')
+    response.set_cookie('session', 'abc123')
+    return response
+"""
+
+    code_file = CodeFile(path="app.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cookie_findings = [f for f in result.findings if "cookie" in f.message.lower() or "Cookie" in f.message]
+    assert len(cookie_findings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_detect_django_session_cookie_samesite_none():
+    """Test detection of SESSION_COOKIE_SAMESITE = None."""
+    code = """
+SESSION_COOKIE_SAMESITE = None
+"""
+
+    code_file = CodeFile(path="settings.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cookie_findings = [f for f in result.findings if "SameSite" in f.message]
+    assert len(cookie_findings) >= 1
+
+
+# ============================================================================
+# Missing Helmet Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_detect_express_without_helmet():
+    """Test detection of Express app without helmet middleware."""
+    code = """
+const express = require('express');
+const app = express();
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    helmet_findings = [f for f in result.findings if "helmet" in f.message.lower()]
+    assert len(helmet_findings) >= 1
+
+
+@pytest.mark.asyncio
+async def test_pass_express_with_helmet():
+    """Test that Express app with helmet passes."""
+    code = """
+const express = require('express');
+const helmet = require('helmet');
+const app = express();
+
+app.use(helmet());
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.js", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    # No helmet findings
+    helmet_findings = [f for f in result.findings if "helmet" in f.message.lower()]
+    assert len(helmet_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_helmet_check_non_express():
+    """Test that helmet check is skipped for non-Express files."""
+    code = """
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/api/data')
+async def get_data():
+    return {"data": "test"}
+"""
+
+    code_file = CodeFile(path="main.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    # No helmet findings for Python
+    helmet_findings = [f for f in result.findings if "helmet" in f.message.lower()]
+    assert len(helmet_findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_detect_express_esm_without_helmet():
+    """Test detection of Express ESM import without helmet."""
+    code = """
+import express from 'express';
+const app = express();
+
+app.get('/api/data', (req, res) => {
+    res.json({ data: 'test' });
+});
+
+app.listen(3000);
+"""
+
+    code_file = CodeFile(path="server.mjs", content=code, language="javascript")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    helmet_findings = [f for f in result.findings if "helmet" in f.message.lower()]
+    assert len(helmet_findings) >= 1
+
+
+# ============================================================================
+# Edge Cases
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_clean_code_passes():
+    """Test that clean code with no HTTP security issues passes."""
+    code = """
+def calculate(a, b):
+    return a + b
+
+result = calculate(1, 2)
+print(result)
+"""
+
+    code_file = CodeFile(path="utils.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is True
+    assert len(result.findings) == 0
+
+
+@pytest.mark.asyncio
+async def test_check_metadata():
+    """Test that check has correct metadata."""
+    check = HTTPSecurityCheck()
+
+    assert check.id == "http-security"
+    assert check.name == "HTTP Security Misconfiguration Detection"
+    assert check.severity.value == "high"
+    assert check.enabled_by_default is True
+
+
+@pytest.mark.asyncio
+async def test_detect_access_control_allow_origin_wildcard():
+    """Test detection of Access-Control-Allow-Origin: * header."""
+    code = """
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.after_request
+def add_cors_headers(response):
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+"""
+
+    code_file = CodeFile(path="app.py", content=code, language="python")
+    check = HTTPSecurityCheck()
+    result = await check.execute_async(code_file)
+
+    assert result.passed is False
+    cors_findings = [f for f in result.findings if "CORS" in f.message or "Access-Control" in f.message]
+    assert len(cors_findings) >= 1


### PR DESCRIPTION
## Summary
- Add `HTTPSecurityCheck` detector for CORS misconfigurations (wildcard origins in Express/Django/FastAPI/Flask), insecure cookie settings (missing `Secure`/`HttpOnly`/`SameSite` flags), and missing `helmet()` middleware in Express apps
- Add `CSRFCheck` detector for disabled CSRF protection: Django `@csrf_exempt` decorators, missing `CsrfViewMiddleware`, Flask apps without `flask-wtf` `CSRFProtect`, and Express apps with state-changing routes but no `csurf` middleware
- Register both checks in `SecurityFrame._register_builtin_checks()` with corresponding config keys

Closes #94, Closes #95

## Test plan
- [x] 19 tests for `HTTPSecurityCheck` covering CORS wildcard detection (Express/Django/FastAPI), cookie flag validation, helmet middleware detection, comment skipping, and edge cases
- [x] 18 tests for `CSRFCheck` covering Django `@csrf_exempt` detection, missing middleware, Flask CSRFProtect, Express csurf, GET-only apps, async views, and language filtering
- [x] All 299 existing security frame tests continue to pass
- [x] Run `python3 -m pytest tests/validation/frames/security/ -x` -- 299 passed