### PR TITLE
fix(security): add AST and data flow analysis to batch mode

### DIFF
--- a/tests/validation/frames/security/test_batch_parity.py
+++ b/tests/validation/frames/security/test_batch_parity.py
@@ -4,6 +4,7 @@ Tests for batch mode execution parity with single mode.
 Verifies:
 1. Batch mode produces similar results to single mode (includes AST/taint)
 2. Batch mode handles errors gracefully when some files fail
+3. Batch mode runs AST extraction and data flow analysis (not just pattern checks)
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -29,7 +30,7 @@ class TestSecurityFrameBatchParity:
 
     @pytest.mark.asyncio
     async def test_batch_mode_produces_findings_like_single_mode(self, security_frame):
-        """Batch execution delegates to execute_async per file, so results match."""
+        """Batch execution runs the same analysis pipeline as single mode."""
         code_files = [
             CodeFile(
                 path="/tmp/app.py",
@@ -55,7 +56,7 @@ class TestSecurityFrameBatchParity:
         # Both should return same count
         assert len(batch_results) == len(code_files)
 
-        # Batch delegates to execute_async, so finding counts should match
+        # Finding counts should match between single and batch
         for i in range(len(code_files)):
             assert batch_results[i].issues_found == single_results[i].issues_found
 
@@ -106,3 +107,170 @@ class TestSecurityFrameBatchParity:
         assert len(batch_results) == 1
         assert isinstance(batch_results[0], FrameResult)
         assert batch_results[0].frame_id == security_frame.frame_id
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_calls_ast_extraction(self, security_frame):
+        """Batch mode invokes extract_ast_context for each file."""
+        code_files = [
+            CodeFile(path="/tmp/a.py", content="x = eval(input())", language="python"),
+            CodeFile(path="/tmp/b.py", content="y = 1 + 2", language="python"),
+        ]
+
+        with patch(
+            "warden.validation.frames.security.frame.extract_ast_context",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_ast:
+            await security_frame.execute_batch_async(code_files)
+
+        # AST extraction should be called once per file
+        assert mock_ast.call_count == len(code_files)
+        called_paths = [call.args[0].path for call in mock_ast.call_args_list]
+        assert "/tmp/a.py" in called_paths
+        assert "/tmp/b.py" in called_paths
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_calls_data_flow_analysis(self, security_frame):
+        """Batch mode invokes analyze_data_flow when check results exist."""
+        from warden.validation.domain.check import CheckFinding, CheckResult, CheckSeverity
+
+        code_files = [
+            CodeFile(
+                path="/tmp/vuln.py",
+                content='query = f"SELECT * FROM users WHERE id = {uid}"',
+                language="python",
+            ),
+        ]
+
+        # Register a mock check that produces a finding so check_results is non-empty
+        mock_check = MagicMock()
+        mock_check.name = "mock-check"
+        mock_check.execute_async = AsyncMock(return_value=CheckResult(
+            check_id="mock",
+            check_name="Mock Check",
+            passed=False,
+            findings=[
+                CheckFinding(
+                    check_id="mock",
+                    check_name="Mock Check",
+                    severity=CheckSeverity.HIGH,
+                    message="test finding",
+                    location="/tmp/vuln.py:1",
+                    suggestion="fix it",
+                ),
+            ],
+        ))
+        security_frame.checks.register(mock_check)
+
+        with patch(
+            "warden.validation.frames.security.frame.analyze_data_flow",
+            new_callable=AsyncMock,
+            return_value={"tainted_paths": [], "blast_radius": [], "data_sources": []},
+        ) as mock_df:
+            await security_frame.execute_batch_async(code_files)
+
+        # Data flow analysis should be called for the file with findings
+        assert mock_df.call_count == 1
+        assert mock_df.call_args.args[0].path == "/tmp/vuln.py"
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_metadata_includes_ast_analysis(self, security_frame):
+        """Batch results contain ast_analysis in metadata when AST data is available."""
+        code_files = [
+            CodeFile(path="/tmp/test.py", content="exec(user_input)", language="python"),
+        ]
+
+        fake_ast = {
+            "dangerous_calls": [{"name": "exec", "line": 1}],
+            "sql_queries": [],
+            "input_sources": [{"name": "user_input", "line": 1}],
+            "string_concatenations": [],
+        }
+
+        with patch(
+            "warden.validation.frames.security.frame.extract_ast_context",
+            new_callable=AsyncMock,
+            return_value=fake_ast,
+        ):
+            results = await security_frame.execute_batch_async(code_files)
+
+        metadata = results[0].metadata
+        assert "ast_analysis" in metadata
+        assert metadata["ast_analysis"]["dangerous_calls_found"] == 1
+        assert metadata["ast_analysis"]["input_sources_found"] == 1
+
+    @pytest.mark.asyncio
+    async def test_batch_mode_metadata_includes_data_flow(self, security_frame):
+        """Batch results contain data_flow_analysis in metadata when data flow is available."""
+        from warden.validation.domain.check import CheckFinding, CheckResult, CheckSeverity
+
+        code_files = [
+            CodeFile(path="/tmp/test.py", content="x = 1", language="python"),
+        ]
+
+        # Need a check that produces findings to trigger data flow analysis
+        mock_check = MagicMock()
+        mock_check.name = "mock"
+        mock_check.execute_async = AsyncMock(return_value=CheckResult(
+            check_id="mock",
+            check_name="Mock",
+            passed=False,
+            findings=[
+                CheckFinding(
+                    check_id="mock",
+                    check_name="Mock",
+                    severity=CheckSeverity.MEDIUM,
+                    message="test",
+                    location="/tmp/test.py:1",
+                    suggestion="fix",
+                ),
+            ],
+        ))
+        security_frame.checks.register(mock_check)
+
+        fake_data_flow = {
+            "tainted_paths": ["/tmp/test.py:1 -> /tmp/test.py:5"],
+            "blast_radius": ["/tmp/other.py"],
+            "data_sources": ["/tmp/test.py:1"],
+        }
+
+        with patch(
+            "warden.validation.frames.security.frame.analyze_data_flow",
+            new_callable=AsyncMock,
+            return_value=fake_data_flow,
+        ):
+            results = await security_frame.execute_batch_async(code_files)
+
+        metadata = results[0].metadata
+        assert "data_flow_analysis" in metadata
+        assert metadata["data_flow_analysis"]["tainted_paths_found"] == 1
+        assert metadata["data_flow_analysis"]["blast_radius_files"] == 1
+        assert metadata["data_flow_analysis"]["data_sources_traced"] == 1
+        assert metadata["tainted_paths"] == fake_data_flow["tainted_paths"]
+
+    @pytest.mark.asyncio
+    async def test_batch_and_single_mode_metadata_parity(self, security_frame):
+        """Both modes populate the same metadata keys for analysis results."""
+        code_files = [
+            CodeFile(path="/tmp/app.py", content="x = 1", language="python"),
+        ]
+
+        fake_ast = {
+            "dangerous_calls": [],
+            "sql_queries": [],
+            "input_sources": [],
+            "string_concatenations": [],
+        }
+
+        with patch(
+            "warden.validation.frames.security.frame.extract_ast_context",
+            new_callable=AsyncMock,
+            return_value=fake_ast,
+        ):
+            single_result = await security_frame.execute_async(code_files[0])
+            batch_results = await security_frame.execute_batch_async(code_files)
+
+        # Core metadata keys should be present in both
+        for key in ("checks_executed", "checks_passed", "checks_failed"):
+            assert key in single_result.metadata, f"Single mode missing key: {key}"
+            assert key in batch_results[0].metadata, f"Batch mode missing key: {key}"


### PR DESCRIPTION
## Summary
- Add tree-sitter AST extraction (`extract_ast_context`) to `execute_batch_async`, matching the analysis pipeline in `execute_async` (single-file mode)
- Add LSP data flow analysis (`analyze_data_flow`) to batch mode for taint tracking across check results
- Enrich batch result metadata with `ast_analysis`, `taint_analysis`, and `data_flow_analysis` sections, achieving full parity with single-file mode metadata

Closes #64

## Test plan
- [x] Existing `test_batch_parity.py` tests pass (batch produces same findings as single mode)
- [x] New test: `test_batch_mode_calls_ast_extraction` verifies AST extraction is invoked per file in batch
- [x] New test: `test_batch_mode_calls_data_flow_analysis` verifies data flow analysis runs when findings exist
- [x] New test: `test_batch_mode_metadata_includes_ast_analysis` verifies metadata enrichment for AST
- [x] New test: `test_batch_mode_metadata_includes_data_flow` verifies metadata enrichment for data flow
- [x] New test: `test_batch_and_single_mode_metadata_parity` verifies both modes share core metadata keys
- [x] All 267 security frame tests pass