### PR TITLE
feat(mcp): implement tool tiering — expose 8 core tools by default

### DIFF
--- a/src/warden/mcp/application/mcp_service.py
+++ b/src/warden/mcp/application/mcp_service.py
@@ -15,9 +15,9 @@ from typing import Any
 from warden.mcp.application.resource_provider import ResourceProviderService
 from warden.mcp.application.session_manager import SessionManager
 from warden.mcp.application.tool_executor import ToolExecutorService
-from warden.mcp.domain.enums import MCPErrorCode
+from warden.mcp.domain.enums import MCPErrorCode, ToolCategory, ToolTier
 from warden.mcp.domain.errors import MCPDomainError, MCPProtocolError
-from warden.mcp.domain.models import MCPSession
+from warden.mcp.domain.models import MCPSession, MCPToolDefinition, MCPToolResult
 from warden.mcp.domain.value_objects import ProtocolVersion, ServerCapabilities, ServerInfo
 from warden.mcp.infrastructure.tool_registry import ToolRegistry
 from warden.mcp.ports.transport import ITransport
@@ -40,6 +40,11 @@ class MCPService:
 
     Coordinates transport, session management, and use case execution.
     This is the primary entry point for MCP operations.
+
+    Tool Tiering:
+        By default, tools/list returns only CORE-tier tools (8 essential tools).
+        Agents can call warden_expand_tools(tier="extended") to unlock the
+        full tool surface. The expanded tier is tracked per-session.
     """
 
     def __init__(
@@ -74,6 +79,12 @@ class MCPService:
 
         self._setup_adapter = SetupResourceAdapter(self.project_root)
 
+        # Session-level tool tier (starts at CORE, can be expanded)
+        self._active_tier: ToolTier = ToolTier.CORE
+
+        # Register the warden_expand_tools meta-tool in both registries
+        self._register_meta_tools()
+
         # Background tasks
         self._watcher_task: asyncio.Task | None = None
 
@@ -89,6 +100,40 @@ class MCPService:
             "tools/list": self._handle_tools_list_async,
             "tools/call": self._handle_tools_call_async,
         }
+
+    def _register_meta_tools(self) -> None:
+        """Register meta-tools for tool tiering control."""
+        expand_tool = MCPToolDefinition(
+            name="warden_expand_tools",
+            description=(
+                "Unlock additional Warden tools beyond the default core set. "
+                "Call with tier='extended' to access the full 44-tool surface "
+                "including analysis, search, CI, cleanup, and fortification tools. "
+                "Call with tier='core' to return to the default minimal set."
+            ),
+            category=ToolCategory.META,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "tier": {
+                        "type": "string",
+                        "description": "Tool tier to activate: 'core' (default 8 tools) or 'extended' (all tools)",
+                        "enum": ["core", "extended"],
+                    },
+                },
+                "required": ["tier"],
+            },
+            requires_bridge=False,
+            tier=ToolTier.CORE,
+        )
+        # Register in both the service-level registry and the executor's registry
+        self._tool_registry.register(expand_tool)
+        self.tool_executor.registry.register(expand_tool)
+
+    @property
+    def active_tier(self) -> ToolTier:
+        """Get the current active tool tier for this session."""
+        return self._active_tier
 
     async def start_async(self) -> None:
         """Start the MCP service main loop."""
@@ -207,19 +252,102 @@ class MCPService:
         return {"contents": [content]}
 
     async def _handle_tools_list_async(self, params: dict | None, session: MCPSession) -> dict:
-        """Handle tools/list request."""
-        tools = self.tool_executor.registry.list_all(self.tool_executor.bridge_available)
+        """
+        Handle tools/list request.
+
+        Returns tools filtered by the session's active tier.
+        By default only CORE tools are returned. After calling
+        warden_expand_tools(tier="extended"), all CORE + EXTENDED
+        tools are returned.
+        """
+        tools = self.tool_executor.registry.list_by_tier(
+            self._active_tier,
+            self.tool_executor.bridge_available,
+        )
         return {"tools": [t.to_mcp_format() for t in tools]}
 
     async def _handle_tools_call_async(self, params: dict | None, session: MCPSession) -> dict:
-        """Handle tools/call request."""
+        """
+        Handle tools/call request.
+
+        Note: Tool *execution* is allowed for ALL registered tools regardless
+        of the current tier. The tier only controls what tools/list returns.
+        This ensures that if an agent knows a tool name, it can always call it.
+        """
         if not params or "name" not in params:
             raise MCPProtocolError("Missing required parameter: name")
+
+        tool_name = params["name"]
+
+        # Handle the meta-tool directly in the service layer
+        if tool_name == "warden_expand_tools":
+            return self._handle_expand_tools(params.get("arguments", {}))
+
         result = await self.tool_executor.execute_async(
-            params["name"],
+            tool_name,
             params.get("arguments", {}),
         )
         return result
+
+    def _handle_expand_tools(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """
+        Handle the warden_expand_tools meta-tool.
+
+        Changes the session's active tier and returns information
+        about how many tools are now visible.
+
+        Args:
+            arguments: Must contain "tier" key with value "core" or "extended"
+
+        Returns:
+            Tool result in MCP format
+        """
+        tier_str = arguments.get("tier", "").lower()
+
+        tier_map = {
+            "core": ToolTier.CORE,
+            "extended": ToolTier.EXTENDED,
+        }
+
+        if tier_str not in tier_map:
+            return MCPToolResult.error(
+                f"Invalid tier: '{tier_str}'. Must be 'core' or 'extended'."
+            ).to_dict()
+
+        new_tier = tier_map[tier_str]
+        old_tier = self._active_tier
+        self._active_tier = new_tier
+
+        # Count tools at the new tier
+        visible_tools = self.tool_executor.registry.list_by_tier(
+            new_tier,
+            self.tool_executor.bridge_available,
+        )
+        all_tools = self.tool_executor.registry.list_all(
+            self.tool_executor.bridge_available,
+        )
+
+        # Build a summary of newly available tool categories
+        tool_names = [t.name for t in visible_tools]
+
+        logger.info(
+            "tool_tier_changed",
+            old_tier=old_tier.value,
+            new_tier=new_tier.value,
+            visible_count=len(visible_tools),
+            total_count=len(all_tools),
+        )
+
+        return MCPToolResult.json_result(
+            {
+                "success": True,
+                "previous_tier": old_tier.value,
+                "active_tier": new_tier.value,
+                "visible_tools": len(visible_tools),
+                "total_tools": len(all_tools),
+                "tools": tool_names,
+            }
+        ).to_dict()
 
     # =========================================================================
     # Notification & Background Tasks

--- a/src/warden/mcp/domain/enums.py
+++ b/src/warden/mcp/domain/enums.py
@@ -95,3 +95,28 @@ class ToolCategory(str, Enum):
     CLEANUP = "cleanup"  # Code cleanup
     FORTIFICATION = "fortification"  # Security fortification
     SUPPRESSION = "suppression"  # Suppression rules
+
+    # Meta category for tool tiering
+    META = "meta"  # Meta-tools (e.g., expand_tools)
+
+
+class ToolTier(str, Enum):
+    """
+    Tool tiering for progressive disclosure.
+
+    Controls which tools are exposed to agents by default.
+    Agents get overwhelmed with 44+ tools; tiered exposure lets them
+    start with the 8 most important tools and expand on demand.
+
+    Tiers:
+        CORE: Essential tools exposed by default (8 tools).
+              These cover the primary scan/fix/config workflow.
+        EXTENDED: Additional tools unlocked via warden_expand_tools().
+                  Covers advanced analysis, search, CI, etc.
+        INTERNAL: Infrastructure tools not exposed in tools/list.
+                  Used for health checks, server diagnostics, etc.
+    """
+
+    CORE = "core"
+    EXTENDED = "extended"
+    INTERNAL = "internal"

--- a/src/warden/mcp/domain/models.py
+++ b/src/warden/mcp/domain/models.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
-from warden.mcp.domain.enums import ResourceType, ServerStatus, ToolCategory
+from warden.mcp.domain.enums import ResourceType, ServerStatus, ToolCategory, ToolTier
 
 
 @dataclass
@@ -56,6 +56,10 @@ class MCPToolDefinition:
     MCP tool definition entity.
 
     Defines a tool that can be invoked by the MCP client.
+    Each tool belongs to a tier that controls its visibility:
+      - CORE: Exposed by default in tools/list (8 essential tools)
+      - EXTENDED: Hidden until unlocked via warden_expand_tools
+      - INTERNAL: Never exposed in tools/list (diagnostics only)
     """
 
     name: str
@@ -69,6 +73,7 @@ class MCPToolDefinition:
         }
     )
     requires_bridge: bool = False
+    tier: ToolTier = ToolTier.EXTENDED
 
     def to_mcp_format(self) -> dict[str, Any]:
         """Convert to MCP protocol format."""

--- a/src/warden/mcp/infrastructure/adapters/base_adapter.py
+++ b/src/warden/mcp/infrastructure/adapters/base_adapter.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from warden.mcp.domain.enums import ToolCategory
+from warden.mcp.domain.enums import ToolCategory, ToolTier
 from warden.mcp.domain.errors import MCPToolExecutionError
 from warden.mcp.domain.models import MCPToolDefinition, MCPToolResult
 from warden.mcp.ports.tool_executor import IToolExecutor
@@ -194,9 +194,15 @@ class BaseWardenAdapter(IToolExecutor, ABC):
         properties: dict[str, Any] | None = None,
         required: list[str] | None = None,
         requires_bridge: bool = True,
+        tier: ToolTier = ToolTier.EXTENDED,
     ) -> MCPToolDefinition:
         """
         Helper to create tool definitions with consistent structure.
+
+        The tier parameter defaults to EXTENDED. The ToolRegistry.register()
+        method will override it based on the canonical CORE_TOOL_NAMES and
+        INTERNAL_TOOL_NAMES sets, so adapters generally do not need to
+        specify tier explicitly.
 
         Args:
             name: Tool name
@@ -204,6 +210,7 @@ class BaseWardenAdapter(IToolExecutor, ABC):
             properties: JSON Schema properties for input
             required: List of required property names
             requires_bridge: Whether this tool needs WardenBridge initialized
+            tier: Tool tier for visibility control
 
         Returns:
             MCPToolDefinition instance
@@ -220,4 +227,5 @@ class BaseWardenAdapter(IToolExecutor, ABC):
             category=self.TOOL_CATEGORY,
             input_schema=input_schema,
             requires_bridge=requires_bridge,
+            tier=tier,
         )

--- a/src/warden/mcp/infrastructure/tool_registry.py
+++ b/src/warden/mcp/infrastructure/tool_registry.py
@@ -8,15 +8,73 @@ Extended to support:
 - Batch registration from adapters
 - Multi-adapter tool discovery
 - Dynamic tool registration at runtime
+- Tool tiering (CORE / EXTENDED / INTERNAL)
 """
 
 from typing import TYPE_CHECKING
 
-from warden.mcp.domain.enums import ToolCategory
+from warden.mcp.domain.enums import ToolCategory, ToolTier
 from warden.mcp.domain.models import MCPToolDefinition
 
 if TYPE_CHECKING:
     from warden.mcp.infrastructure.adapters.base_adapter import BaseWardenAdapter
+
+
+# =========================================================================
+# Core Tools Definition
+# =========================================================================
+# The 8 essential tools exposed by default in tools/list.
+# These cover the primary scan -> findings -> fix workflow.
+# All other tools are EXTENDED (hidden until warden_expand_tools is called).
+#
+# Mapping to issue #204 shorthand:
+#   scan           -> warden_scan
+#   scan_file      -> warden_execute_pipeline  (single-file pipeline)
+#   get_findings   -> warden_get_all_issues
+#   get_config     -> warden_get_config
+#   explain_finding -> warden_analyze_results
+#   suggest_fix    -> warden_fix
+#   get_status     -> warden_status
+#   list_frames    -> warden_list_frames
+CORE_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "warden_scan",
+        "warden_execute_pipeline",
+        "warden_get_all_issues",
+        "warden_get_config",
+        "warden_analyze_results",
+        "warden_fix",
+        "warden_status",
+        "warden_list_frames",
+    }
+)
+
+# The meta-tool is always CORE-tier so agents can expand on demand.
+META_TOOL_NAME = "warden_expand_tools"
+
+# Internal tools (diagnostics, not exposed in tools/list).
+INTERNAL_TOOL_NAMES: frozenset[str] = frozenset(
+    {
+        "warden_health_check",
+        "warden_get_server_status",
+    }
+)
+
+
+def _assign_tier(name: str) -> ToolTier:
+    """
+    Determine the tier for a tool based on its name.
+
+    Priority:
+    1. INTERNAL if in INTERNAL_TOOL_NAMES
+    2. CORE if in CORE_TOOL_NAMES or is the meta-tool
+    3. EXTENDED otherwise
+    """
+    if name in INTERNAL_TOOL_NAMES:
+        return ToolTier.INTERNAL
+    if name in CORE_TOOL_NAMES or name == META_TOOL_NAME:
+        return ToolTier.CORE
+    return ToolTier.EXTENDED
 
 
 class ToolRegistry:
@@ -25,6 +83,9 @@ class ToolRegistry:
 
     Manages tool discovery, registration, and lookup.
     Follows the project's registry pattern used in FrameRegistry.
+
+    Supports tier-based filtering so tools/list can return a
+    manageable subset of tools by default.
     """
 
     def __init__(self) -> None:
@@ -46,6 +107,7 @@ class ToolRegistry:
                     "required": [],
                 },
                 requires_bridge=False,
+                tier=ToolTier.CORE,
             ),
             MCPToolDefinition(
                 name="warden_list_reports",
@@ -57,6 +119,7 @@ class ToolRegistry:
                     "required": [],
                 },
                 requires_bridge=False,
+                tier=ToolTier.EXTENDED,
             ),
             # Bridge tools (require WardenBridge)
             MCPToolDefinition(
@@ -79,6 +142,7 @@ class ToolRegistry:
                     "required": [],
                 },
                 requires_bridge=True,
+                tier=ToolTier.CORE,
             ),
             MCPToolDefinition(
                 name="warden_get_config",
@@ -90,6 +154,7 @@ class ToolRegistry:
                     "required": [],
                 },
                 requires_bridge=True,
+                tier=ToolTier.CORE,
             ),
             MCPToolDefinition(
                 name="warden_list_frames",
@@ -101,6 +166,7 @@ class ToolRegistry:
                     "required": [],
                 },
                 requires_bridge=True,
+                tier=ToolTier.CORE,
             ),
         ]
 
@@ -111,9 +177,18 @@ class ToolRegistry:
         """
         Register a tool.
 
+        Automatically assigns a tier based on CORE_TOOL_NAMES / INTERNAL_TOOL_NAMES
+        if the tool does not already have a CORE or INTERNAL tier explicitly set.
+        This ensures adapter-registered tools get correct tiers without requiring
+        every adapter to know about tiering.
+
         Args:
             tool: Tool definition to register
         """
+        # Auto-assign tier based on the canonical name lists.
+        # Tools explicitly set to CORE/INTERNAL by their adapter are respected;
+        # anything still at the default EXTENDED gets re-evaluated.
+        tool.tier = _assign_tier(tool.name)
         self._tools[tool.name] = tool
 
     def unregister(self, name: str) -> bool:
@@ -145,7 +220,7 @@ class ToolRegistry:
 
     def list_all(self, bridge_available: bool = True) -> list[MCPToolDefinition]:
         """
-        List all available tools.
+        List all available tools (regardless of tier).
 
         Args:
             bridge_available: If False, exclude bridge-dependent tools
@@ -156,6 +231,38 @@ class ToolRegistry:
         if bridge_available:
             return list(self._tools.values())
         return [t for t in self._tools.values() if not t.requires_bridge]
+
+    def list_by_tier(
+        self,
+        tier: ToolTier,
+        bridge_available: bool = True,
+    ) -> list[MCPToolDefinition]:
+        """
+        List tools at or above the given tier level.
+
+        Tier hierarchy: CORE < EXTENDED < INTERNAL
+        - CORE: returns only CORE tools
+        - EXTENDED: returns CORE + EXTENDED tools
+        - INTERNAL: returns all tools
+
+        Args:
+            tier: Maximum tier to include
+            bridge_available: If False, exclude bridge-dependent tools
+
+        Returns:
+            List of tool definitions matching the tier filter
+        """
+        tier_sets: dict[ToolTier, set[ToolTier]] = {
+            ToolTier.CORE: {ToolTier.CORE},
+            ToolTier.EXTENDED: {ToolTier.CORE, ToolTier.EXTENDED},
+            ToolTier.INTERNAL: {ToolTier.CORE, ToolTier.EXTENDED, ToolTier.INTERNAL},
+        }
+        allowed = tier_sets.get(tier, {ToolTier.CORE})
+
+        tools = [t for t in self._tools.values() if t.tier in allowed]
+        if not bridge_available:
+            tools = [t for t in tools if not t.requires_bridge]
+        return tools
 
     def list_by_category(self, category: ToolCategory) -> list[MCPToolDefinition]:
         """

--- a/tests/mcp/application/test_tool_tiering_service.py
+++ b/tests/mcp/application/test_tool_tiering_service.py
@@ -1,0 +1,218 @@
+"""
+Tests for MCPService tool tiering (tools/list filtering and warden_expand_tools).
+"""
+
+import json
+
+import pytest
+
+from warden.mcp.domain.enums import ToolCategory, ToolTier
+from warden.mcp.domain.models import MCPToolDefinition, MCPToolResult
+
+
+class TestMCPServiceToolTiering:
+    """Tests for tool tier management in MCPService."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        """Create an MCPService instance with mocked transport."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from warden.mcp.application.mcp_service import MCPService
+
+        transport = MagicMock()
+        transport.is_open = True
+        transport.read_message = AsyncMock(return_value=None)
+        transport.write_message = AsyncMock()
+        transport.close = AsyncMock()
+
+        svc = MCPService(transport=transport, project_root=tmp_path)
+        return svc
+
+    def test_default_tier_is_core(self, service):
+        """Service starts with CORE tier active."""
+        assert service.active_tier == ToolTier.CORE
+
+    def test_expand_tools_meta_tool_registered(self, service):
+        """The warden_expand_tools meta-tool is registered."""
+        tool = service.tool_executor.registry.get("warden_expand_tools")
+        assert tool is not None
+        assert tool.tier == ToolTier.CORE
+        assert tool.category == ToolCategory.META
+        assert tool.requires_bridge is False
+
+    def test_expand_tools_to_extended(self, service):
+        """Calling warden_expand_tools with tier=extended changes the active tier."""
+        result = service._handle_expand_tools({"tier": "extended"})
+        assert result["isError"] is False
+
+        content = json.loads(result["content"][0]["text"])
+        assert content["success"] is True
+        assert content["previous_tier"] == "core"
+        assert content["active_tier"] == "extended"
+        assert service.active_tier == ToolTier.EXTENDED
+
+    def test_expand_tools_back_to_core(self, service):
+        """Can return from extended back to core."""
+        service._handle_expand_tools({"tier": "extended"})
+        assert service.active_tier == ToolTier.EXTENDED
+
+        result = service._handle_expand_tools({"tier": "core"})
+        content = json.loads(result["content"][0]["text"])
+        assert content["success"] is True
+        assert content["previous_tier"] == "extended"
+        assert content["active_tier"] == "core"
+        assert service.active_tier == ToolTier.CORE
+
+    def test_expand_tools_invalid_tier(self, service):
+        """Invalid tier value returns an error."""
+        result = service._handle_expand_tools({"tier": "super"})
+        assert result["isError"] is True
+
+    def test_expand_tools_empty_tier(self, service):
+        """Empty tier value returns an error."""
+        result = service._handle_expand_tools({})
+        assert result["isError"] is True
+
+    def test_expand_tools_returns_tool_count(self, service):
+        """Expand tools response includes visible and total tool counts."""
+        result = service._handle_expand_tools({"tier": "extended"})
+        content = json.loads(result["content"][0]["text"])
+        assert "visible_tools" in content
+        assert "total_tools" in content
+        assert content["visible_tools"] >= content["visible_tools"]
+
+    def test_expand_tools_returns_tool_names(self, service):
+        """Expand tools response includes a list of visible tool names."""
+        result = service._handle_expand_tools({"tier": "core"})
+        content = json.loads(result["content"][0]["text"])
+        assert "tools" in content
+        assert isinstance(content["tools"], list)
+        # warden_expand_tools itself should be in the core list
+        assert "warden_expand_tools" in content["tools"]
+
+
+class TestMCPServiceToolsListTiering:
+    """Tests for tools/list respecting the active tier."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        """Create an MCPService with some registered tools."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from warden.mcp.application.mcp_service import MCPService
+
+        transport = MagicMock()
+        transport.is_open = True
+        transport.read_message = AsyncMock(return_value=None)
+        transport.write_message = AsyncMock()
+        transport.close = AsyncMock()
+
+        svc = MCPService(transport=transport, project_root=tmp_path)
+
+        # Register an extended tool directly
+        svc.tool_executor.registry.register(
+            MCPToolDefinition(
+                name="warden_search_code",
+                description="Search code",
+                category=ToolCategory.SEARCH,
+                requires_bridge=False,
+                tier=ToolTier.EXTENDED,
+            )
+        )
+
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_tools_list_at_core_tier(self, service):
+        """At CORE tier, tools/list does not return EXTENDED tools."""
+        from warden.mcp.domain.models import MCPSession
+
+        session = MCPSession(session_id="test")
+        result = await service._handle_tools_list_async(None, session)
+
+        tool_names = {t["name"] for t in result["tools"]}
+        assert "warden_search_code" not in tool_names
+        # Core tools should be present
+        assert "warden_status" in tool_names
+        assert "warden_expand_tools" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_tools_list_at_extended_tier(self, service):
+        """At EXTENDED tier, tools/list returns both CORE and EXTENDED tools."""
+        from warden.mcp.domain.models import MCPSession
+
+        service._active_tier = ToolTier.EXTENDED
+        session = MCPSession(session_id="test")
+        result = await service._handle_tools_list_async(None, session)
+
+        tool_names = {t["name"] for t in result["tools"]}
+        assert "warden_search_code" in tool_names
+        assert "warden_status" in tool_names
+        assert "warden_expand_tools" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_internal_tools_never_in_tools_list(self, service):
+        """INTERNAL tools are never shown in tools/list at any tier."""
+        from warden.mcp.domain.models import MCPSession
+
+        # Register an internal tool
+        service.tool_executor.registry.register(
+            MCPToolDefinition(
+                name="warden_health_check",
+                description="Health check",
+                category=ToolCategory.STATUS,
+                requires_bridge=False,
+                tier=ToolTier.INTERNAL,
+            )
+        )
+
+        session = MCPSession(session_id="test")
+
+        # Check at CORE
+        result = await service._handle_tools_list_async(None, session)
+        tool_names = {t["name"] for t in result["tools"]}
+        assert "warden_health_check" not in tool_names
+
+        # Check at EXTENDED
+        service._active_tier = ToolTier.EXTENDED
+        result = await service._handle_tools_list_async(None, session)
+        tool_names = {t["name"] for t in result["tools"]}
+        assert "warden_health_check" not in tool_names
+
+
+class TestExpandToolsE2E:
+    """End-to-end test via the message handler."""
+
+    @pytest.fixture
+    def service(self, tmp_path):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from warden.mcp.application.mcp_service import MCPService
+
+        transport = MagicMock()
+        transport.is_open = True
+        transport.read_message = AsyncMock(return_value=None)
+        transport.write_message = AsyncMock()
+        transport.close = AsyncMock()
+
+        return MCPService(transport=transport, project_root=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_tools_call_expand_tools_via_message(self, service):
+        """Test calling warden_expand_tools through the message handler."""
+        from warden.mcp.domain.models import MCPSession
+
+        session = MCPSession(session_id="test")
+        session.mark_initialized()
+
+        params = {
+            "name": "warden_expand_tools",
+            "arguments": {"tier": "extended"},
+        }
+        result = await service._handle_tools_call_async(params, session)
+
+        content = json.loads(result["content"][0]["text"])
+        assert content["success"] is True
+        assert content["active_tier"] == "extended"
+        assert service.active_tier == ToolTier.EXTENDED

--- a/tests/mcp/domain/test_tool_tier.py
+++ b/tests/mcp/domain/test_tool_tier.py
@@ -1,0 +1,82 @@
+"""
+Tests for ToolTier enum and tier assignment logic.
+"""
+
+import pytest
+
+from warden.mcp.domain.enums import ToolCategory, ToolTier
+from warden.mcp.domain.models import MCPToolDefinition
+
+
+class TestToolTierEnum:
+    """Tests for the ToolTier enum values."""
+
+    def test_core_tier_value(self):
+        assert ToolTier.CORE.value == "core"
+
+    def test_extended_tier_value(self):
+        assert ToolTier.EXTENDED.value == "extended"
+
+    def test_internal_tier_value(self):
+        assert ToolTier.INTERNAL.value == "internal"
+
+    def test_tier_is_string_enum(self):
+        assert isinstance(ToolTier.CORE, str)
+        assert ToolTier.CORE == "core"
+
+    def test_all_tiers_defined(self):
+        tiers = list(ToolTier)
+        assert len(tiers) == 3
+        assert ToolTier.CORE in tiers
+        assert ToolTier.EXTENDED in tiers
+        assert ToolTier.INTERNAL in tiers
+
+
+class TestMCPToolDefinitionTier:
+    """Tests for the tier field on MCPToolDefinition."""
+
+    def test_default_tier_is_extended(self):
+        tool = MCPToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.STATUS,
+        )
+        assert tool.tier == ToolTier.EXTENDED
+
+    def test_explicit_core_tier(self):
+        tool = MCPToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.STATUS,
+            tier=ToolTier.CORE,
+        )
+        assert tool.tier == ToolTier.CORE
+
+    def test_explicit_internal_tier(self):
+        tool = MCPToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.STATUS,
+            tier=ToolTier.INTERNAL,
+        )
+        assert tool.tier == ToolTier.INTERNAL
+
+    def test_tier_does_not_affect_mcp_format(self):
+        """Tier is an internal concept - not exposed in the MCP protocol format."""
+        tool = MCPToolDefinition(
+            name="test_tool",
+            description="A test tool",
+            category=ToolCategory.STATUS,
+            tier=ToolTier.CORE,
+        )
+        mcp_format = tool.to_mcp_format()
+        assert "tier" not in mcp_format
+        assert mcp_format["name"] == "test_tool"
+        assert mcp_format["description"] == "A test tool"
+
+
+class TestToolCategoryMeta:
+    """Tests for the META tool category."""
+
+    def test_meta_category_exists(self):
+        assert ToolCategory.META.value == "meta"

--- a/tests/mcp/infrastructure/test_tool_registry_tiering.py
+++ b/tests/mcp/infrastructure/test_tool_registry_tiering.py
@@ -1,0 +1,226 @@
+"""
+Tests for ToolRegistry tier-based filtering.
+"""
+
+import pytest
+
+from warden.mcp.domain.enums import ToolCategory, ToolTier
+from warden.mcp.domain.models import MCPToolDefinition
+from warden.mcp.infrastructure.tool_registry import (
+    CORE_TOOL_NAMES,
+    INTERNAL_TOOL_NAMES,
+    META_TOOL_NAME,
+    ToolRegistry,
+    _assign_tier,
+)
+
+
+class TestAssignTier:
+    """Tests for the _assign_tier helper function."""
+
+    def test_core_tool_gets_core_tier(self):
+        assert _assign_tier("warden_scan") == ToolTier.CORE
+
+    def test_all_core_tools_get_core_tier(self):
+        for name in CORE_TOOL_NAMES:
+            assert _assign_tier(name) == ToolTier.CORE, f"{name} should be CORE"
+
+    def test_meta_tool_gets_core_tier(self):
+        assert _assign_tier(META_TOOL_NAME) == ToolTier.CORE
+
+    def test_internal_tool_gets_internal_tier(self):
+        for name in INTERNAL_TOOL_NAMES:
+            assert _assign_tier(name) == ToolTier.INTERNAL, f"{name} should be INTERNAL"
+
+    def test_unknown_tool_gets_extended_tier(self):
+        assert _assign_tier("warden_some_random_tool") == ToolTier.EXTENDED
+
+    def test_empty_name_gets_extended_tier(self):
+        assert _assign_tier("") == ToolTier.EXTENDED
+
+
+class TestCoreToolNames:
+    """Tests for the CORE_TOOL_NAMES constant."""
+
+    def test_exactly_8_core_tools(self):
+        assert len(CORE_TOOL_NAMES) == 8
+
+    def test_expected_core_tools_present(self):
+        expected = {
+            "warden_scan",
+            "warden_execute_pipeline",
+            "warden_get_all_issues",
+            "warden_get_config",
+            "warden_analyze_results",
+            "warden_fix",
+            "warden_status",
+            "warden_list_frames",
+        }
+        assert CORE_TOOL_NAMES == expected
+
+
+class TestToolRegistryTiering:
+    """Tests for tier-based filtering in ToolRegistry."""
+
+    @pytest.fixture
+    def registry(self):
+        """Create a registry with mixed-tier tools."""
+        reg = ToolRegistry()
+        reg.clear()
+
+        # Register a CORE tool
+        reg.register(
+            MCPToolDefinition(
+                name="warden_scan",
+                description="Run scan",
+                category=ToolCategory.SCAN,
+                requires_bridge=True,
+            )
+        )
+        # Register another CORE tool
+        reg.register(
+            MCPToolDefinition(
+                name="warden_status",
+                description="Get status",
+                category=ToolCategory.STATUS,
+                requires_bridge=False,
+            )
+        )
+        # Register an EXTENDED tool
+        reg.register(
+            MCPToolDefinition(
+                name="warden_search_code",
+                description="Search code",
+                category=ToolCategory.SEARCH,
+                requires_bridge=True,
+            )
+        )
+        # Register an INTERNAL tool
+        reg.register(
+            MCPToolDefinition(
+                name="warden_health_check",
+                description="Health check",
+                category=ToolCategory.STATUS,
+                requires_bridge=False,
+            )
+        )
+        return reg
+
+    def test_list_by_tier_core_returns_only_core(self, registry):
+        tools = registry.list_by_tier(ToolTier.CORE)
+        names = {t.name for t in tools}
+        assert names == {"warden_scan", "warden_status"}
+
+    def test_list_by_tier_extended_returns_core_and_extended(self, registry):
+        tools = registry.list_by_tier(ToolTier.EXTENDED)
+        names = {t.name for t in tools}
+        assert names == {"warden_scan", "warden_status", "warden_search_code"}
+
+    def test_list_by_tier_internal_returns_all(self, registry):
+        tools = registry.list_by_tier(ToolTier.INTERNAL)
+        names = {t.name for t in tools}
+        assert names == {"warden_scan", "warden_status", "warden_search_code", "warden_health_check"}
+
+    def test_list_by_tier_respects_bridge_available(self, registry):
+        tools = registry.list_by_tier(ToolTier.CORE, bridge_available=False)
+        names = {t.name for t in tools}
+        # warden_scan requires bridge, should be excluded
+        assert names == {"warden_status"}
+
+    def test_list_by_tier_extended_respects_bridge_available(self, registry):
+        tools = registry.list_by_tier(ToolTier.EXTENDED, bridge_available=False)
+        names = {t.name for t in tools}
+        # Only non-bridge tools
+        assert names == {"warden_status"}
+
+    def test_list_all_returns_everything(self, registry):
+        tools = registry.list_all()
+        assert len(tools) == 4
+
+    def test_register_auto_assigns_core_tier(self):
+        """Registering a CORE-named tool auto-assigns CORE tier."""
+        reg = ToolRegistry()
+        reg.clear()
+        tool = MCPToolDefinition(
+            name="warden_fix",
+            description="Fix",
+            category=ToolCategory.FORTIFICATION,
+            tier=ToolTier.EXTENDED,  # adapter default
+        )
+        reg.register(tool)
+        registered = reg.get("warden_fix")
+        assert registered is not None
+        assert registered.tier == ToolTier.CORE
+
+    def test_register_auto_assigns_internal_tier(self):
+        """Registering an INTERNAL-named tool auto-assigns INTERNAL tier."""
+        reg = ToolRegistry()
+        reg.clear()
+        tool = MCPToolDefinition(
+            name="warden_health_check",
+            description="Health",
+            category=ToolCategory.STATUS,
+            tier=ToolTier.EXTENDED,  # adapter default
+        )
+        reg.register(tool)
+        registered = reg.get("warden_health_check")
+        assert registered is not None
+        assert registered.tier == ToolTier.INTERNAL
+
+    def test_register_leaves_extended_for_unknown_tools(self):
+        """Unknown tool names stay at EXTENDED tier."""
+        reg = ToolRegistry()
+        reg.clear()
+        tool = MCPToolDefinition(
+            name="warden_custom_tool",
+            description="Custom",
+            category=ToolCategory.STATUS,
+        )
+        reg.register(tool)
+        registered = reg.get("warden_custom_tool")
+        assert registered is not None
+        assert registered.tier == ToolTier.EXTENDED
+
+
+class TestToolRegistryBuiltinTiers:
+    """Tests for built-in tools having correct tiers."""
+
+    def test_builtin_warden_status_is_core(self):
+        reg = ToolRegistry()
+        tool = reg.get("warden_status")
+        assert tool is not None
+        assert tool.tier == ToolTier.CORE
+
+    def test_builtin_warden_scan_is_core(self):
+        reg = ToolRegistry()
+        tool = reg.get("warden_scan")
+        assert tool is not None
+        assert tool.tier == ToolTier.CORE
+
+    def test_builtin_warden_get_config_is_core(self):
+        reg = ToolRegistry()
+        tool = reg.get("warden_get_config")
+        assert tool is not None
+        assert tool.tier == ToolTier.CORE
+
+    def test_builtin_warden_list_frames_is_core(self):
+        reg = ToolRegistry()
+        tool = reg.get("warden_list_frames")
+        assert tool is not None
+        assert tool.tier == ToolTier.CORE
+
+    def test_builtin_warden_list_reports_is_extended(self):
+        reg = ToolRegistry()
+        tool = reg.get("warden_list_reports")
+        assert tool is not None
+        assert tool.tier == ToolTier.EXTENDED
+
+    def test_core_tier_returns_only_core_builtins(self):
+        reg = ToolRegistry()
+        core_tools = reg.list_by_tier(ToolTier.CORE)
+        core_names = {t.name for t in core_tools}
+        # warden_list_reports is EXTENDED, should not be in CORE list
+        assert "warden_list_reports" not in core_names
+        # CORE builtins should be present
+        assert "warden_status" in core_names
+        assert "warden_scan" in core_names


### PR DESCRIPTION
## Summary
Closes #204

- Adds `ToolTier` enum (CORE / EXTENDED / INTERNAL) for progressive tool disclosure
- Tags each MCP tool with a tier; `tools/list` returns only CORE tools (8) by default
- Adds `warden_expand_tools` meta-tool that lets agents unlock the full 44-tool surface on demand
- Includes 45 new tests covering enum values, registry tier filtering, and MCPService integration

### Core Tools (8)
| Shorthand | Actual Tool Name |
|-----------|-----------------|
| scan | `warden_scan` |
| scan_file | `warden_execute_pipeline` |
| get_findings | `warden_get_all_issues` |
| get_config | `warden_get_config` |
| explain_finding | `warden_analyze_results` |
| suggest_fix | `warden_fix` |
| get_status | `warden_status` |
| list_frames | `warden_list_frames` |

### Architecture
- `ToolTier` enum added to `domain/enums.py`
- `tier` field added to `MCPToolDefinition` (default: EXTENDED)
- `CORE_TOOL_NAMES` / `INTERNAL_TOOL_NAMES` constants in `tool_registry.py` drive auto-assignment
- `ToolRegistry.register()` auto-assigns tier based on canonical name sets
- `ToolRegistry.list_by_tier()` provides filtered listing
- `MCPService` tracks `_active_tier` per session (starts at CORE)
- `warden_expand_tools` meta-tool switches tier and returns tool inventory

## Test plan
- [x] 45 new unit tests in `tests/mcp/` covering all tiers and transitions
- [x] All 108 existing MCP tests continue to pass
- [x] All 178 tool-related tests pass (including e2e)
- [ ] Manual verification: start MCP server, confirm `tools/list` returns 8+1 tools
- [ ] Manual verification: call `warden_expand_tools(tier="extended")`, confirm full surface