### PR TITLE
feat(llm+memory): structured prompt caching + typed Citation model

### DIFF
--- a/src/warden/llm/__init__.py
+++ b/src/warden/llm/__init__.py
@@ -9,6 +9,7 @@ Based on C# implementation:
 Public API:
 - LlmProvider: Provider enum
 - LlmRequest/LlmResponse: Request/response types
+- StructuredPrompt: Cacheable prompt separation
 - AnalysisResult/ClassificationResult: Analysis types
 - LlmConfiguration: Configuration management
 - ILlmClient: Provider interface
@@ -21,6 +22,9 @@ from .factory import create_client, create_client_with_fallback_async, create_pr
 from .prompts import (
     ANALYSIS_SYSTEM_PROMPT,
     CLASSIFICATION_SYSTEM_PROMPT,
+    build_analysis_prompt,
+    build_chaos_prompt,
+    build_classification_prompt,
     generate_analysis_request,
     generate_classification_request,
 )
@@ -33,6 +37,7 @@ from .types import (
     LlmProvider,
     LlmRequest,
     LlmResponse,
+    StructuredPrompt,
 )
 
 __all__ = [
@@ -44,6 +49,7 @@ __all__ = [
     "LlmProvider",
     "LlmRequest",
     "LlmResponse",
+    "StructuredPrompt",
     "AnalysisIssue",
     "AnalysisResult",
     "ClassificationCharacteristics",
@@ -57,6 +63,9 @@ __all__ = [
     # Prompts
     "ANALYSIS_SYSTEM_PROMPT",
     "generate_analysis_request",
+    "build_analysis_prompt",
     "CLASSIFICATION_SYSTEM_PROMPT",
     "generate_classification_request",
+    "build_classification_prompt",
+    "build_chaos_prompt",
 ]

--- a/src/warden/llm/prompts/__init__.py
+++ b/src/warden/llm/prompts/__init__.py
@@ -2,15 +2,19 @@
 LLM Prompts for Code Analysis and Classification
 """
 
-from .analysis import ANALYSIS_SYSTEM_PROMPT, generate_analysis_request
-from .classification import CLASSIFICATION_SYSTEM_PROMPT, generate_classification_request
+from .analysis import ANALYSIS_SYSTEM_PROMPT, build_analysis_prompt, generate_analysis_request
+from .classification import CLASSIFICATION_SYSTEM_PROMPT, build_classification_prompt, generate_classification_request
 from .prompt_manager import PromptManager, get_prompt_manager
+from .resilience import build_chaos_prompt
 
 __all__ = [
     "ANALYSIS_SYSTEM_PROMPT",
     "generate_analysis_request",
+    "build_analysis_prompt",
     "CLASSIFICATION_SYSTEM_PROMPT",
     "generate_classification_request",
+    "build_classification_prompt",
+    "build_chaos_prompt",
     "PromptManager",
     "get_prompt_manager",
 ]

--- a/src/warden/llm/prompts/analysis.py
+++ b/src/warden/llm/prompts/analysis.py
@@ -5,6 +5,10 @@ Based on C# AnalysisPrompt.cs
 Focuses on ACCURACY FIRST with confidence scoring
 """
 
+from __future__ import annotations
+
+from warden.llm.types import StructuredPrompt
+
 ANALYSIS_SYSTEM_PROMPT = """You are Warden, an expert AI Code Guardian specialized in analyzing code quality and security.
 
 Your mission: Provide ACCURATE analysis that developers can trust. Reduce false positives while catching real issues.
@@ -128,3 +132,23 @@ def generate_analysis_request(code: str, language: str, file_path: str | None = 
 </source_code>
 
 Provide detailed analysis following the framework above. Return JSON only."""
+
+
+def build_analysis_prompt(code: str, language: str, file_path: str | None = None) -> StructuredPrompt:
+    """
+    Build a structured prompt for analysis, separating cacheable system
+    context from variable file content.
+
+    Args:
+        code: Code to analyze
+        language: Programming language
+        file_path: Optional file path for context
+
+    Returns:
+        StructuredPrompt with system_context (cacheable) and file_context (variable)
+    """
+    file_context = generate_analysis_request(code, language, file_path)
+    return StructuredPrompt(
+        system_context=ANALYSIS_SYSTEM_PROMPT,
+        file_context=file_context,
+    )

--- a/src/warden/llm/prompts/classification.py
+++ b/src/warden/llm/prompts/classification.py
@@ -5,7 +5,10 @@ Based on C# ClassificationPrompt.cs
 Detects code characteristics and recommends validation frames
 """
 
+from __future__ import annotations
+
 from warden.llm.prompts.tool_instructions import get_tool_enhanced_prompt
+from warden.llm.types import StructuredPrompt
 
 _CLASSIFICATION_BASE_PROMPT = """You are an expert code analyzer specializing in detecting code characteristics and security patterns.
 
@@ -84,3 +87,23 @@ Code:
 ```
 
 Provide your analysis following the format specified in the system prompt. Return JSON only."""
+
+
+def build_classification_prompt(code: str, language: str, file_path: str | None = None) -> StructuredPrompt:
+    """
+    Build a structured prompt for classification, separating cacheable system
+    context from variable file content.
+
+    Args:
+        code: Code to classify
+        language: Programming language
+        file_path: Optional file path for context
+
+    Returns:
+        StructuredPrompt with system_context (cacheable) and file_context (variable)
+    """
+    file_context = generate_classification_request(code, language, file_path)
+    return StructuredPrompt(
+        system_context=CLASSIFICATION_SYSTEM_PROMPT,
+        file_context=file_context,
+    )

--- a/src/warden/llm/prompts/resilience.py
+++ b/src/warden/llm/prompts/resilience.py
@@ -4,6 +4,10 @@ Chaos Engineering & Resilience System Prompt
 Performs Failure Mode & Effects Analysis (FMEA) on code.
 """
 
+from __future__ import annotations
+
+from warden.llm.types import StructuredPrompt
+
 CHAOS_SYSTEM_PROMPT = """You are a Chaos Engineer. Your mindset: "Everything will fail. The question is HOW and WHEN."
 
 ## YOUR APPROACH (Context-Aware Chaos Engineering)
@@ -119,3 +123,26 @@ Think like a chaos engineer:
 3. What resilience patterns are MISSING?
 
 Return JSON with your analysis."""
+
+
+def build_chaos_prompt(
+    code: str, language: str, file_path: str | None = None, context: dict | None = None
+) -> StructuredPrompt:
+    """
+    Build a structured prompt for chaos/resilience analysis, separating
+    cacheable system context from variable file content.
+
+    Args:
+        code: Source code to analyze
+        language: Programming language
+        file_path: Optional file path for context
+        context: Optional dict with detected dependencies/triggers
+
+    Returns:
+        StructuredPrompt with system_context (cacheable) and file_context (variable)
+    """
+    file_context = generate_chaos_request(code, language, file_path, context)
+    return StructuredPrompt(
+        system_context=CHAOS_SYSTEM_PROMPT,
+        file_context=file_context,
+    )

--- a/src/warden/memory/domain/__init__.py
+++ b/src/warden/memory/domain/__init__.py
@@ -1,1 +1,9 @@
 """Memory domain module."""
+
+from .models import Citation, Fact, KnowledgeGraph
+
+__all__ = [
+    "Citation",
+    "Fact",
+    "KnowledgeGraph",
+]

--- a/tests/llm/providers/test_prompt_caching.py
+++ b/tests/llm/providers/test_prompt_caching.py
@@ -1,0 +1,98 @@
+"""Tests for provider-level StructuredPrompt / cache_control support."""
+
+from warden.llm.types import StructuredPrompt
+from warden.llm.providers.anthropic import AnthropicClient
+from warden.llm.providers.openai import OpenAIClient
+
+
+class TestAnthropicCachePayload:
+    """Tests for AnthropicClient.build_system_payload."""
+
+    def test_plain_string_fallback(self):
+        """Without structured prompt, returns plain string."""
+        result = AnthropicClient.build_system_payload("You are Warden.")
+        assert result == "You are Warden."
+
+    def test_structured_prompt_produces_blocks(self):
+        """With StructuredPrompt, returns list of content blocks."""
+        sp = StructuredPrompt(
+            system_context="Severity guide + rules",
+            file_context="File: test.py\nCode: x=1",
+        )
+        result = AnthropicClient.build_system_payload("ignored", sp)
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_first_block_has_cache_control(self):
+        """First block (system_context) should have cache_control hint."""
+        sp = StructuredPrompt(
+            system_context="Stable context",
+            file_context="Variable content",
+        )
+        result = AnthropicClient.build_system_payload("ignored", sp)
+        first_block = result[0]
+        assert first_block["type"] == "text"
+        assert first_block["text"] == "Stable context"
+        assert first_block["cache_control"] == {"type": "ephemeral"}
+
+    def test_second_block_no_cache_control(self):
+        """Second block (file_context) should NOT have cache_control."""
+        sp = StructuredPrompt(
+            system_context="Stable",
+            file_context="Variable",
+        )
+        result = AnthropicClient.build_system_payload("ignored", sp)
+        second_block = result[1]
+        assert second_block["type"] == "text"
+        assert second_block["text"] == "Variable"
+        assert "cache_control" not in second_block
+
+
+class TestOpenAICacheMessages:
+    """Tests for OpenAIClient.build_messages."""
+
+    def test_plain_fallback(self):
+        """Without structured prompt, returns standard 2-message layout."""
+        result = OpenAIClient.build_messages("sys", "user")
+        assert len(result) == 2
+        assert result[0] == {"role": "system", "content": "sys"}
+        assert result[1] == {"role": "user", "content": "user"}
+
+    def test_structured_prompt_produces_three_messages(self):
+        """With StructuredPrompt, returns 3 messages for cache-friendly prefix."""
+        sp = StructuredPrompt(
+            system_context="Stable system context",
+            file_context="Variable file context",
+        )
+        result = OpenAIClient.build_messages("ignored", "user msg", sp)
+        assert len(result) == 3
+
+    def test_first_message_is_system_context(self):
+        """First message should be system role with system_context."""
+        sp = StructuredPrompt(
+            system_context="Cacheable rules",
+            file_context="Per-file data",
+        )
+        result = OpenAIClient.build_messages("ignored", "user", sp)
+        assert result[0]["role"] == "system"
+        assert result[0]["content"] == "Cacheable rules"
+
+    def test_second_message_is_file_context(self):
+        """Second message should be system role with file_context."""
+        sp = StructuredPrompt(
+            system_context="Rules",
+            file_context="File data",
+        )
+        result = OpenAIClient.build_messages("ignored", "user", sp)
+        assert result[1]["role"] == "system"
+        assert result[1]["content"] == "File data"
+
+    def test_third_message_is_user(self):
+        """Third message should be user role with user_message."""
+        sp = StructuredPrompt(
+            system_context="Rules",
+            file_context="File",
+        )
+        result = OpenAIClient.build_messages("ignored", "Analyze this", sp)
+        assert result[2]["role"] == "user"
+        assert result[2]["content"] == "Analyze this"

--- a/tests/llm/test_structured_prompt.py
+++ b/tests/llm/test_structured_prompt.py
@@ -1,0 +1,193 @@
+"""Tests for StructuredPrompt and prompt builder integration."""
+
+import pytest
+
+from warden.llm.types import StructuredPrompt
+from warden.llm.prompts.analysis import (
+    ANALYSIS_SYSTEM_PROMPT,
+    build_analysis_prompt,
+    generate_analysis_request,
+)
+from warden.llm.prompts.classification import (
+    CLASSIFICATION_SYSTEM_PROMPT,
+    build_classification_prompt,
+    generate_classification_request,
+)
+from warden.llm.prompts.resilience import (
+    CHAOS_SYSTEM_PROMPT,
+    build_chaos_prompt,
+    generate_chaos_request,
+)
+
+
+class TestStructuredPrompt:
+    """Unit tests for StructuredPrompt dataclass."""
+
+    def test_creation(self):
+        """Test basic StructuredPrompt creation."""
+        sp = StructuredPrompt(
+            system_context="You are Warden.",
+            file_context="Analyze this code: print('hello')",
+        )
+        assert sp.system_context == "You are Warden."
+        assert sp.file_context == "Analyze this code: print('hello')"
+
+    def test_frozen(self):
+        """Test that StructuredPrompt is immutable."""
+        sp = StructuredPrompt(system_context="ctx", file_context="file")
+        with pytest.raises(AttributeError):
+            sp.system_context = "modified"
+
+    def test_to_single_prompt(self):
+        """Test flattening to a single prompt string."""
+        sp = StructuredPrompt(
+            system_context="System instructions here.",
+            file_context="File content here.",
+        )
+        result = sp.to_single_prompt()
+        assert "System instructions here." in result
+        assert "File content here." in result
+        assert result == "System instructions here.\n\nFile content here."
+
+    def test_equality(self):
+        """Test dataclass equality comparison."""
+        sp1 = StructuredPrompt(system_context="a", file_context="b")
+        sp2 = StructuredPrompt(system_context="a", file_context="b")
+        assert sp1 == sp2
+
+    def test_inequality(self):
+        """Test dataclass inequality."""
+        sp1 = StructuredPrompt(system_context="a", file_context="b")
+        sp2 = StructuredPrompt(system_context="a", file_context="c")
+        assert sp1 != sp2
+
+    def test_empty_contexts(self):
+        """Test with empty strings."""
+        sp = StructuredPrompt(system_context="", file_context="")
+        assert sp.to_single_prompt() == "\n\n"
+
+
+class TestBuildAnalysisPrompt:
+    """Tests for build_analysis_prompt."""
+
+    def test_returns_structured_prompt(self):
+        """build_analysis_prompt should return a StructuredPrompt."""
+        sp = build_analysis_prompt(
+            code="def hello(): pass",
+            language="python",
+            file_path="test.py",
+        )
+        assert isinstance(sp, StructuredPrompt)
+
+    def test_system_context_matches_constant(self):
+        """System context should be the ANALYSIS_SYSTEM_PROMPT."""
+        sp = build_analysis_prompt(code="x = 1", language="python")
+        assert sp.system_context == ANALYSIS_SYSTEM_PROMPT
+
+    def test_file_context_contains_code(self):
+        """File context should contain the source code."""
+        sp = build_analysis_prompt(
+            code="import os\nos.system('rm -rf /')",
+            language="python",
+            file_path="danger.py",
+        )
+        assert "os.system" in sp.file_context
+        assert "danger.py" in sp.file_context
+
+    def test_file_context_matches_generate(self):
+        """File context should match generate_analysis_request output."""
+        code = "x = 1"
+        lang = "python"
+        path = "test.py"
+        sp = build_analysis_prompt(code, lang, path)
+        expected = generate_analysis_request(code, lang, path)
+        assert sp.file_context == expected
+
+    def test_no_file_path(self):
+        """Should work without file_path."""
+        sp = build_analysis_prompt(code="x = 1", language="python")
+        assert isinstance(sp, StructuredPrompt)
+        assert "File:" not in sp.file_context
+
+
+class TestBuildClassificationPrompt:
+    """Tests for build_classification_prompt."""
+
+    def test_returns_structured_prompt(self):
+        """build_classification_prompt should return a StructuredPrompt."""
+        sp = build_classification_prompt(
+            code="async def fetch(): pass",
+            language="python",
+        )
+        assert isinstance(sp, StructuredPrompt)
+
+    def test_system_context_matches_constant(self):
+        """System context should be the CLASSIFICATION_SYSTEM_PROMPT."""
+        sp = build_classification_prompt(code="x = 1", language="python")
+        assert sp.system_context == CLASSIFICATION_SYSTEM_PROMPT
+
+    def test_file_context_contains_code(self):
+        """File context should contain the source code."""
+        sp = build_classification_prompt(
+            code="async def fetch(): await api.get()",
+            language="python",
+            file_path="fetcher.py",
+        )
+        assert "async def fetch" in sp.file_context
+
+    def test_file_context_matches_generate(self):
+        """File context should match generate_classification_request."""
+        code = "x = 1"
+        lang = "python"
+        sp = build_classification_prompt(code, lang)
+        expected = generate_classification_request(code, lang)
+        assert sp.file_context == expected
+
+
+class TestBuildChaosPrompt:
+    """Tests for build_chaos_prompt."""
+
+    def test_returns_structured_prompt(self):
+        """build_chaos_prompt should return a StructuredPrompt."""
+        sp = build_chaos_prompt(
+            code="conn = db.connect()",
+            language="python",
+        )
+        assert isinstance(sp, StructuredPrompt)
+
+    def test_system_context_matches_constant(self):
+        """System context should be the CHAOS_SYSTEM_PROMPT."""
+        sp = build_chaos_prompt(code="x = 1", language="python")
+        assert sp.system_context == CHAOS_SYSTEM_PROMPT
+
+    def test_with_context(self):
+        """Should include context info in file_context."""
+        sp = build_chaos_prompt(
+            code="db.query('SELECT 1')",
+            language="python",
+            file_path="repo.py",
+            context={"dependencies": ["database", "redis"]},
+        )
+        assert "database" in sp.file_context
+        assert "redis" in sp.file_context
+
+    def test_file_context_matches_generate(self):
+        """File context should match generate_chaos_request."""
+        code = "x = 1"
+        lang = "python"
+        ctx = {"dependencies": ["api"]}
+        sp = build_chaos_prompt(code, lang, context=ctx)
+        expected = generate_chaos_request(code, lang, context=ctx)
+        assert sp.file_context == expected
+
+
+class TestStructuredPromptImports:
+    """Test that StructuredPrompt is importable from expected locations."""
+
+    def test_import_from_types(self):
+        from warden.llm.types import StructuredPrompt as SP
+        assert SP is StructuredPrompt
+
+    def test_import_from_llm_init(self):
+        from warden.llm import StructuredPrompt as SP
+        assert SP is StructuredPrompt

--- a/tests/memory/domain/test_citation.py
+++ b/tests/memory/domain/test_citation.py
@@ -1,0 +1,253 @@
+"""Tests for Citation model and Fact.citations integration."""
+
+import json
+
+from warden.memory.domain.models import Citation, Fact, KnowledgeGraph
+
+
+class TestCitation:
+    """Unit tests for the Citation dataclass."""
+
+    def test_creation_minimal(self):
+        """Test Citation with only required field."""
+        c = Citation(file="src/main.py")
+        assert c.file == "src/main.py"
+        assert c.line is None
+        assert c.text == ""
+
+    def test_creation_full(self):
+        """Test Citation with all fields."""
+        c = Citation(file="src/auth.py", line=42, text="def login():")
+        assert c.file == "src/auth.py"
+        assert c.line == 42
+        assert c.text == "def login():"
+
+    def test_frozen(self):
+        """Test that Citation is immutable (frozen=True)."""
+        c = Citation(file="test.py", line=1)
+        try:
+            c.file = "other.py"
+            assert False, "Should have raised an error"
+        except AttributeError:
+            pass
+
+    def test_equality(self):
+        """Test dataclass equality comparison."""
+        c1 = Citation(file="a.py", line=10, text="x")
+        c2 = Citation(file="a.py", line=10, text="x")
+        assert c1 == c2
+
+    def test_inequality(self):
+        """Test dataclass inequality."""
+        c1 = Citation(file="a.py", line=10)
+        c2 = Citation(file="a.py", line=20)
+        assert c1 != c2
+
+    def test_hash(self):
+        """Test that Citation is hashable (frozen dataclass)."""
+        c = Citation(file="a.py", line=1)
+        s = {c}
+        assert c in s
+
+    def test_as_dict_key(self):
+        """Test Citation can be used as dict key (hashable)."""
+        c = Citation(file="a.py", line=1)
+        d = {c: "found"}
+        assert d[c] == "found"
+
+
+class TestFactCitations:
+    """Tests for Fact.citations field and helper methods."""
+
+    def test_fact_default_empty_citations(self):
+        """New Fact should have empty citations list."""
+        f = Fact(
+            category="test",
+            subject="TestClass",
+            predicate="has",
+            object="method",
+        )
+        assert f.citations == []
+
+    def test_fact_with_citations(self):
+        """Fact can be created with citations as list of dicts."""
+        f = Fact(
+            category="test",
+            subject="TestClass",
+            predicate="has",
+            object="method",
+            citations=[
+                {"file": "src/test.py", "line": 10, "text": "class TestClass:"},
+                {"file": "src/test.py", "line": 20},
+            ],
+        )
+        assert len(f.citations) == 2
+
+    def test_get_citations(self):
+        """get_citations should return typed Citation objects."""
+        f = Fact(
+            category="test",
+            subject="X",
+            predicate="p",
+            object="o",
+            citations=[
+                {"file": "a.py", "line": 5, "text": "import os"},
+                {"file": "b.py"},
+            ],
+        )
+        typed = f.get_citations()
+        assert len(typed) == 2
+        assert isinstance(typed[0], Citation)
+        assert typed[0].file == "a.py"
+        assert typed[0].line == 5
+        assert typed[0].text == "import os"
+        assert typed[1].file == "b.py"
+        assert typed[1].line is None
+        assert typed[1].text == ""
+
+    def test_add_citation(self):
+        """add_citation should return a new Fact with citation appended."""
+        f = Fact(
+            category="test",
+            subject="X",
+            predicate="p",
+            object="o",
+        )
+        c = Citation(file="src/x.py", line=42, text="def method():")
+        f2 = f.add_citation(c)
+
+        # Original unchanged
+        assert len(f.citations) == 0
+        # New fact has citation
+        assert len(f2.citations) == 1
+        assert f2.citations[0]["file"] == "src/x.py"
+        assert f2.citations[0]["line"] == 42
+        assert f2.citations[0]["text"] == "def method():"
+
+    def test_add_citation_minimal(self):
+        """add_citation with minimal Citation (no line, no text)."""
+        f = Fact(category="t", subject="s", predicate="p", object="o")
+        c = Citation(file="only_file.py")
+        f2 = f.add_citation(c)
+        assert f2.citations[0]["file"] == "only_file.py"
+        assert "line" not in f2.citations[0]
+        assert "text" not in f2.citations[0]
+
+    def test_add_multiple_citations(self):
+        """Chaining add_citation should accumulate citations."""
+        f = Fact(category="t", subject="s", predicate="p", object="o")
+        f = f.add_citation(Citation(file="a.py", line=1))
+        f = f.add_citation(Citation(file="b.py", line=2))
+        f = f.add_citation(Citation(file="c.py", line=3))
+        assert len(f.citations) == 3
+        assert f.citations[2]["file"] == "c.py"
+
+
+class TestFactCitationSerialization:
+    """Test that citations survive JSON round-trips."""
+
+    def test_to_json_includes_citations(self):
+        """Fact.to_json should include citations."""
+        f = Fact(
+            category="test",
+            subject="X",
+            predicate="p",
+            object="o",
+            citations=[{"file": "a.py", "line": 10, "text": "hello"}],
+        )
+        data = f.to_json()
+        assert "citations" in data
+        assert len(data["citations"]) == 1
+        assert data["citations"][0]["file"] == "a.py"
+
+    def test_from_json_with_citations(self):
+        """Fact.from_json should restore citations."""
+        data = {
+            "category": "test",
+            "subject": "X",
+            "predicate": "p",
+            "object": "o",
+            "citations": [
+                {"file": "src/x.py", "line": 5, "text": "import x"},
+            ],
+        }
+        f = Fact.from_json(data)
+        assert len(f.citations) == 1
+        typed = f.get_citations()
+        assert typed[0].file == "src/x.py"
+        assert typed[0].line == 5
+
+    def test_json_roundtrip(self):
+        """Full JSON serialization round-trip with citations."""
+        f = Fact(
+            category="arch",
+            subject="AuthService",
+            predicate="implements",
+            object="JWT",
+            citations=[
+                {"file": "src/auth.py", "line": 1, "text": "class AuthService:"},
+                {"file": "src/jwt.py", "line": 15},
+            ],
+        )
+        json_str = json.dumps(f.to_json())
+        data = json.loads(json_str)
+        f2 = Fact.from_json(data)
+
+        assert len(f2.citations) == 2
+        typed = f2.get_citations()
+        assert typed[0].file == "src/auth.py"
+        assert typed[1].file == "src/jwt.py"
+        assert typed[1].line == 15
+
+    def test_backward_compatible_no_citations(self):
+        """Fact without citations field should still deserialize."""
+        data = {
+            "category": "test",
+            "subject": "Old",
+            "predicate": "existed",
+            "object": "before_citations",
+        }
+        f = Fact.from_json(data)
+        assert f.citations == []
+        assert f.get_citations() == []
+
+
+class TestKnowledgeGraphWithCitations:
+    """Test KnowledgeGraph round-trip with citation-bearing facts."""
+
+    def test_knowledge_graph_roundtrip(self):
+        """KnowledgeGraph serialization should preserve citations."""
+        kg = KnowledgeGraph()
+        f = Fact(
+            id="test-1",
+            category="rule",
+            subject="NoSQL",
+            predicate="uses",
+            object="MongoDB",
+            citations=[{"file": "config.py", "line": 3, "text": "MONGO_URI = ..."}],
+        )
+        kg.add_fact(f)
+
+        # Serialize
+        data = kg.to_json()
+        json_str = json.dumps(data)
+
+        # Deserialize
+        data2 = json.loads(json_str)
+        kg2 = KnowledgeGraph.from_json(data2)
+
+        restored = kg2.facts["test-1"]
+        assert len(restored.citations) == 1
+        assert restored.citations[0]["file"] == "config.py"
+
+
+class TestCitationImports:
+    """Test that Citation is importable from expected locations."""
+
+    def test_import_from_models(self):
+        from warden.memory.domain.models import Citation as C
+        assert C is Citation
+
+    def test_import_from_domain_init(self):
+        from warden.memory.domain import Citation as C
+        assert C is Citation


### PR DESCRIPTION
## Summary

- **StructuredPrompt** (#200): Add `StructuredPrompt` frozen dataclass that separates stable system context from variable file content. LLM providers can now cache the static portion across multiple file analyses within the same scan run.
  - Anthropic: `cache_control: {"type": "ephemeral"}` hint on system context block
  - OpenAI: Split system messages for automatic prefix caching
  - Backwards compatible: existing `send_async` unchanged, new `send_structured_async` + `build_*_prompt()` helpers added
- **Citation** (#203): Add frozen `Citation` dataclass with `file`, `line`, `text` fields. Extend `Fact` model with `citations: list[dict]` field and typed accessor methods (`get_citations()`, `add_citation()`). Full JSON round-trip support.

## Test plan

- [x] 68 unit tests passing for StructuredPrompt, Citation, and provider cache helpers
- [x] All existing llm/memory/prompt tests remain green
- [x] Backwards compatibility: `Fact` without citations deserializes correctly
- [x] KnowledgeGraph JSON round-trip preserves citations

Closes #200, closes #203