### PR TITLE
fix(pipeline): process isolation for AST parsing + partial scan resume

### DIFF
--- a/src/warden/pipeline/application/orchestrator/ast_pre_parser.py
+++ b/src/warden/pipeline/application/orchestrator/ast_pre_parser.py
@@ -8,10 +8,21 @@ The ast_cache on PipelineContext is an LRU-bounded cache (see
 ``warden.pipeline.domain.lru_cache.LRUCache``).  Eviction is handled
 automatically by the cache when entries exceed its maxsize, so this
 module only needs to insert -- no manual eviction logic is required.
+
+Process Isolation (#100):
+    Tree-sitter parsing is wrapped in a ``ProcessPoolExecutor`` so that
+    a crash (segfault, OOM) inside a single file's native parser does
+    not bring down the entire scan.  Each file is parsed in a separate
+    worker process; if the worker dies the future raises
+    ``BrokenProcessPool`` which is caught and recorded as a ``failed``
+    parse without aborting the scan.
 """
 
 import asyncio
+import os
 import time
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any
 
 from warden.pipeline.domain.pipeline_context import PipelineContext
 from warden.shared.infrastructure.logging import get_logger
@@ -27,13 +38,64 @@ _DEFAULT_TIMEOUT = 10.0
 # The authoritative limit lives in PipelineContext.max_ast_cache_entries.
 _MAX_AST_CACHE_ENTRIES = 500
 
+# Maximum number of worker processes for parse isolation.
+# Defaults to half the available CPUs (minimum 1) to avoid starving the
+# event loop.  Override via WARDEN_AST_WORKERS environment variable.
+_DEFAULT_MAX_WORKERS = max(1, (os.cpu_count() or 2) // 2)
+
+
+def _parse_file_in_worker(
+    content: str,
+    language_value: str,
+    file_path: str,
+) -> Any:
+    """Top-level function executed in a worker process.
+
+    Must be a module-level function (not a method or lambda) so that it
+    is picklable for ``ProcessPoolExecutor``.
+
+    Returns the ``ParseResult`` on success or raises on failure.
+    """
+    import asyncio as _asyncio
+
+    from warden.ast.application.provider_registry import ASTProviderRegistry
+    from warden.ast.domain.enums import CodeLanguage
+
+    lang = CodeLanguage(language_value)
+
+    registry = ASTProviderRegistry()
+    _asyncio.run(registry.discover_providers())
+
+    provider = registry.get_provider(lang)
+    if provider is None:
+        raise RuntimeError(f"No AST provider for {language_value}")
+
+    if hasattr(provider, "ensure_grammar"):
+        _asyncio.run(provider.ensure_grammar(lang))
+
+    result = _asyncio.run(provider.parse(content, lang, file_path))
+    return result
+
 
 class ASTPreParser:
-    """Pre-parses all code files and populates context.ast_cache."""
+    """Pre-parses all code files and populates context.ast_cache.
 
-    def __init__(self, timeout: float = _DEFAULT_TIMEOUT) -> None:
+    When ``use_process_isolation`` is *True* (the default), each file is
+    parsed in a child process via ``ProcessPoolExecutor``.  A worker
+    crash is recorded as a ``failed`` parse but the scan continues.
+    """
+
+    def __init__(
+        self,
+        timeout: float = _DEFAULT_TIMEOUT,
+        *,
+        use_process_isolation: bool = True,
+        max_workers: int | None = None,
+    ) -> None:
         self._timeout = timeout
         self._registry = None
+        self._use_process_isolation = use_process_isolation
+        self._max_workers = max_workers or _DEFAULT_MAX_WORKERS
 
     async def _get_registry(self):
         """Lazy-init the AST provider registry."""
@@ -58,6 +120,12 @@ class ASTPreParser:
         The ast_cache is an LRU cache with automatic eviction; when the
         cache is full the least-recently-used entry is silently dropped
         on the next insertion.
+
+        When process isolation is enabled, parsing is dispatched to a
+        ``ProcessPoolExecutor`` so that native crashes (tree-sitter
+        segfaults) in one file cannot kill the scan.  A worker crash is
+        recorded as a ``failed`` entry in the stats and the scan
+        continues with the remaining files.
         """
         if not code_files:
             return
@@ -67,44 +135,79 @@ class ASTPreParser:
         skipped_cached = 0
         skipped_unsupported = 0
         errors = 0
+        failed = 0
 
         registry = await self._get_registry()
 
         from warden.ast.domain.enums import CodeLanguage
 
+        if self._use_process_isolation:
+            parsed, skipped_cached, skipped_unsupported, errors, failed = (
+                await self._parse_with_process_isolation(
+                    context, code_files, registry, CodeLanguage,
+                )
+            )
+        else:
+            parsed, skipped_cached, skipped_unsupported, errors, failed = (
+                await self._parse_in_process(
+                    context, code_files, registry, CodeLanguage,
+                )
+            )
+
+        duration = time.perf_counter() - start
+
+        if parsed > 0 or errors > 0 or failed > 0:
+            logger.info(
+                "ast_pre_parse_completed",
+                parsed=parsed,
+                skipped_cached=skipped_cached,
+                skipped_unsupported=skipped_unsupported,
+                errors=errors,
+                failed=failed,
+                duration_ms=round(duration * 1000, 1),
+            )
+
+    async def _parse_in_process(
+        self,
+        context: PipelineContext,
+        code_files: list[CodeFile],
+        registry: Any,
+        CodeLanguage: Any,
+    ) -> tuple[int, int, int, int, int]:
+        """Original in-process parsing (no isolation)."""
+        parsed = 0
+        skipped_cached = 0
+        skipped_unsupported = 0
+        errors = 0
+        failed = 0
+
         for code_file in code_files:
-            # Skip if already cached
             if code_file.path in context.ast_cache:
                 skipped_cached += 1
                 continue
 
-            # Resolve language enum
             try:
                 lang = CodeLanguage(code_file.language.lower())
             except (ValueError, AttributeError):
                 skipped_unsupported += 1
                 continue
 
-            # Get best provider for language
             provider = registry.get_provider(lang)
             if not provider:
                 skipped_unsupported += 1
                 continue
 
-            # Ensure grammar is loaded (tree-sitter auto-install)
             if hasattr(provider, "ensure_grammar"):
                 try:
                     await provider.ensure_grammar(lang)
                 except Exception:
-                    pass  # best-effort
+                    pass
 
-            # Parse with per-file timeout
             try:
                 result = await asyncio.wait_for(
                     provider.parse(code_file.content, lang, code_file.path),
                     timeout=self._timeout,
                 )
-                # LRUCache.__setitem__ handles eviction automatically
                 context.ast_cache[code_file.path] = result
                 parsed += 1
             except asyncio.TimeoutError:
@@ -122,14 +225,103 @@ class ASTPreParser:
                 )
                 errors += 1
 
-        duration = time.perf_counter() - start
+        return parsed, skipped_cached, skipped_unsupported, errors, failed
 
-        if parsed > 0 or errors > 0:
-            logger.info(
-                "ast_pre_parse_completed",
-                parsed=parsed,
-                skipped_cached=skipped_cached,
-                skipped_unsupported=skipped_unsupported,
-                errors=errors,
-                duration_ms=round(duration * 1000, 1),
-            )
+    async def _parse_with_process_isolation(
+        self,
+        context: PipelineContext,
+        code_files: list[CodeFile],
+        registry: Any,
+        CodeLanguage: Any,
+    ) -> tuple[int, int, int, int, int]:
+        """Parse files using ProcessPoolExecutor for crash isolation.
+
+        Each file's tree-sitter parse runs in a child process.  If the
+        worker segfaults or raises, the exception is caught and the file
+        is marked as ``failed``; the remaining files are still processed.
+        """
+        parsed = 0
+        skipped_cached = 0
+        skipped_unsupported = 0
+        errors = 0
+        failed = 0
+
+        # Build the list of files eligible for parsing
+        files_to_parse: list[CodeFile] = []
+        for code_file in code_files:
+            if code_file.path in context.ast_cache:
+                skipped_cached += 1
+                continue
+
+            try:
+                CodeLanguage(code_file.language.lower())
+            except (ValueError, AttributeError):
+                skipped_unsupported += 1
+                continue
+
+            provider = registry.get_provider(CodeLanguage(code_file.language.lower()))
+            if not provider:
+                skipped_unsupported += 1
+                continue
+
+            files_to_parse.append(code_file)
+
+        if not files_to_parse:
+            return parsed, skipped_cached, skipped_unsupported, errors, failed
+
+        loop = asyncio.get_running_loop()
+
+        # Use ProcessPoolExecutor for isolation.  The pool is created
+        # per-call so that a broken pool from a previous crash does not
+        # contaminate subsequent batches.
+        executor = ProcessPoolExecutor(max_workers=self._max_workers)
+        try:
+            for code_file in files_to_parse:
+                lang_value = code_file.language.lower()
+                try:
+                    future = loop.run_in_executor(
+                        executor,
+                        _parse_file_in_worker,
+                        code_file.content,
+                        lang_value,
+                        code_file.path,
+                    )
+                    result = await asyncio.wait_for(future, timeout=self._timeout)
+                    context.ast_cache[code_file.path] = result
+                    parsed += 1
+                except asyncio.TimeoutError:
+                    logger.debug(
+                        "ast_pre_parse_timeout",
+                        file=code_file.path,
+                        timeout=self._timeout,
+                    )
+                    errors += 1
+                except Exception as e:
+                    # BrokenProcessPool, RuntimeError from worker crash,
+                    # or any other exception from the child process.
+                    error_type = type(e).__name__
+                    is_worker_crash = "BrokenProcessPool" in error_type or "broken" in str(e).lower()
+                    if is_worker_crash:
+                        logger.warning(
+                            "ast_pre_parse_worker_crash",
+                            file=code_file.path,
+                            error=str(e),
+                        )
+                        failed += 1
+                        # Re-create the executor after a broken pool
+                        try:
+                            executor.shutdown(wait=False)
+                        except Exception:
+                            pass
+                        executor = ProcessPoolExecutor(max_workers=self._max_workers)
+                    else:
+                        logger.debug(
+                            "ast_pre_parse_error",
+                            file=code_file.path,
+                            error=str(e),
+                        )
+                        errors += 1
+        finally:
+            executor.shutdown(wait=False)
+
+        return parsed, skipped_cached, skipped_unsupported, errors, failed

--- a/src/warden/pipeline/application/orchestrator/partial_results_writer.py
+++ b/src/warden/pipeline/application/orchestrator/partial_results_writer.py
@@ -1,0 +1,272 @@
+"""
+Partial Results Writer -- incremental scan persistence (#101).
+
+Writes findings to ``.warden/cache/partial_results.jsonl`` after each
+file's frame execution completes so that progress survives crashes.
+
+Lifecycle:
+    1. ``append(file_path, frame_id, findings)`` -- called after each
+       file finishes; appends one JSON line to the JSONL file.
+    2. ``commit()`` -- called on clean completion; deletes the partial
+       results file.
+    3. On ``SIGINT`` / ``SIGTERM`` the current buffer is flushed
+       automatically (signal handler installed at construction time).
+
+Resume support:
+    ``load_completed_keys()`` returns a ``set[str]`` of
+    ``(frame_id, file_path)`` tuples that have already been scanned.
+    The scan loop can skip those entries when ``--resume`` is active.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from warden.shared.infrastructure.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Default location relative to project root
+_DEFAULT_PARTIAL_DIR = ".warden/cache"
+_DEFAULT_PARTIAL_FILENAME = "partial_results.jsonl"
+
+
+class PartialResultsWriter:
+    """Append-only JSONL writer for incremental scan persistence.
+
+    Thread-safe: the ``append`` method acquires a lock before writing.
+    """
+
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        *,
+        install_signal_handlers: bool = True,
+    ) -> None:
+        root = project_root or Path.cwd()
+        self._dir = root / _DEFAULT_PARTIAL_DIR
+        self._path = self._dir / _DEFAULT_PARTIAL_FILENAME
+        self._lock = threading.Lock()
+        self._fd: Any = None
+        self._entry_count = 0
+
+        # Ensure the directory exists (idempotent).
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+        if install_signal_handlers:
+            self._install_signal_handlers()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def path(self) -> Path:
+        """Return the path to the partial results JSONL file."""
+        return self._path
+
+    def append(
+        self,
+        file_path: str,
+        frame_id: str,
+        findings: list[dict[str, Any]],
+    ) -> None:
+        """Append a single scan result line (one file x one frame).
+
+        Args:
+            file_path: The source file that was scanned.
+            frame_id: The validation frame that produced the findings.
+            findings: A list of finding dicts (may be empty for clean files).
+        """
+        record = {
+            "file": file_path,
+            "frame_id": frame_id,
+            "findings": findings,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+
+        with self._lock:
+            self._ensure_open()
+            line = json.dumps(record, default=str) + "\n"
+            self._fd.write(line)
+            self._fd.flush()
+            os.fsync(self._fd.fileno())
+            self._entry_count += 1
+
+    def flush(self) -> None:
+        """Force-flush the underlying file descriptor."""
+        with self._lock:
+            if self._fd is not None and not self._fd.closed:
+                self._fd.flush()
+                os.fsync(self._fd.fileno())
+
+    def commit(self) -> None:
+        """Mark the scan as complete by removing partial results.
+
+        Call this on clean scan completion.
+        """
+        with self._lock:
+            self._close()
+            if self._path.exists():
+                self._path.unlink()
+                logger.debug(
+                    "partial_results_committed",
+                    path=str(self._path),
+                    entries=self._entry_count,
+                )
+            self._entry_count = 0
+
+    def close(self) -> None:
+        """Close the file handle without deleting the file."""
+        with self._lock:
+            self._close()
+
+    # ------------------------------------------------------------------
+    # Resume support
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def has_partial_results(cls, project_root: Path | None = None) -> bool:
+        """Check whether a partial results file exists."""
+        root = project_root or Path.cwd()
+        path = root / _DEFAULT_PARTIAL_DIR / _DEFAULT_PARTIAL_FILENAME
+        return path.exists() and path.stat().st_size > 0
+
+    @classmethod
+    def load_completed_keys(
+        cls, project_root: Path | None = None
+    ) -> set[tuple[str, str]]:
+        """Load ``{(frame_id, file_path), ...}`` from existing partial results.
+
+        Returns an empty set when no partial results exist or on parse
+        errors.
+        """
+        root = project_root or Path.cwd()
+        path = root / _DEFAULT_PARTIAL_DIR / _DEFAULT_PARTIAL_FILENAME
+        keys: set[tuple[str, str]] = set()
+
+        if not path.exists():
+            return keys
+
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        frame_id = record.get("frame_id", "")
+                        file_path = record.get("file", "")
+                        if frame_id and file_path:
+                            keys.add((frame_id, file_path))
+                    except json.JSONDecodeError:
+                        logger.debug(
+                            "partial_results_bad_line",
+                            line_num=line_num,
+                            path=str(path),
+                        )
+        except OSError as e:
+            logger.warning(
+                "partial_results_load_failed",
+                path=str(path),
+                error=str(e),
+            )
+
+        if keys:
+            logger.info(
+                "partial_results_loaded",
+                entries=len(keys),
+                path=str(path),
+            )
+
+        return keys
+
+    @classmethod
+    def load_findings(
+        cls, project_root: Path | None = None
+    ) -> list[dict[str, Any]]:
+        """Load all findings from partial results for report merging.
+
+        Returns a flat list of finding dicts collected from every line
+        in the JSONL file.
+        """
+        root = project_root or Path.cwd()
+        path = root / _DEFAULT_PARTIAL_DIR / _DEFAULT_PARTIAL_FILENAME
+        all_findings: list[dict[str, Any]] = []
+
+        if not path.exists():
+            return all_findings
+
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                        findings = record.get("findings", [])
+                        if findings:
+                            all_findings.extend(findings)
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            pass
+
+        return all_findings
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_open(self) -> None:
+        """Open the JSONL file in append mode if not already open."""
+        if self._fd is None or self._fd.closed:
+            self._fd = open(self._path, "a", encoding="utf-8")
+
+    def _close(self) -> None:
+        """Close the file descriptor if open."""
+        if self._fd is not None and not self._fd.closed:
+            try:
+                self._fd.flush()
+                os.fsync(self._fd.fileno())
+            except OSError:
+                pass
+            self._fd.close()
+            self._fd = None
+
+    def _install_signal_handlers(self) -> None:
+        """Install SIGINT/SIGTERM handlers to flush on crash.
+
+        Only installs from the main thread (signal module requirement).
+        Preserves any previously registered handler by chaining.
+        """
+        if threading.current_thread() is not threading.main_thread():
+            return
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            prev_handler = signal.getsignal(sig)
+
+            def _handler(signum: int, frame: Any, _prev=prev_handler) -> None:
+                self.flush()
+                self.close()
+                # Re-raise via the previous handler
+                if callable(_prev):
+                    _prev(signum, frame)
+                elif _prev == signal.SIG_DFL:
+                    signal.signal(signum, signal.SIG_DFL)
+                    os.kill(os.getpid(), signum)
+
+            try:
+                signal.signal(sig, _handler)
+            except (OSError, ValueError):
+                # Cannot set signal handler (e.g. not main thread despite
+                # the check above, or platform limitation).
+                pass

--- a/tests/pipeline/application/orchestrator/test_partial_results_writer.py
+++ b/tests/pipeline/application/orchestrator/test_partial_results_writer.py
@@ -1,0 +1,212 @@
+"""Tests for PartialResultsWriter -- incremental scan persistence (#101)."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from warden.pipeline.application.orchestrator.partial_results_writer import (
+    PartialResultsWriter,
+    _DEFAULT_PARTIAL_DIR,
+    _DEFAULT_PARTIAL_FILENAME,
+)
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """Create a temporary project root directory."""
+    return tmp_path
+
+
+@pytest.fixture
+def writer(project_root):
+    """Create a PartialResultsWriter for testing.
+
+    Signal handlers are disabled to avoid interfering with pytest's
+    own signal handling.
+    """
+    w = PartialResultsWriter(
+        project_root=project_root,
+        install_signal_handlers=False,
+    )
+    yield w
+    w.close()
+
+
+class TestPartialResultsAppend:
+    """Tests for the append method."""
+
+    def test_append_creates_jsonl_file(self, writer, project_root):
+        """First append creates the JSONL file."""
+        writer.append("src/app.py", "security_frame", [])
+        assert writer.path.exists()
+
+    def test_append_writes_valid_json_lines(self, writer):
+        """Each append produces a valid JSON line."""
+        writer.append("a.py", "frame_1", [{"id": "F-001", "severity": "high"}])
+        writer.append("b.py", "frame_1", [])
+
+        with open(writer.path) as f:
+            lines = [line.strip() for line in f if line.strip()]
+
+        assert len(lines) == 2
+
+        record_1 = json.loads(lines[0])
+        assert record_1["file"] == "a.py"
+        assert record_1["frame_id"] == "frame_1"
+        assert len(record_1["findings"]) == 1
+        assert record_1["findings"][0]["id"] == "F-001"
+        assert "ts" in record_1
+
+        record_2 = json.loads(lines[1])
+        assert record_2["file"] == "b.py"
+        assert record_2["findings"] == []
+
+    def test_append_with_empty_findings(self, writer):
+        """Clean files produce a line with empty findings list."""
+        writer.append("clean.py", "test_frame", [])
+
+        with open(writer.path) as f:
+            record = json.loads(f.readline())
+
+        assert record["findings"] == []
+
+    def test_append_increments_entry_count(self, writer):
+        """Internal entry counter tracks appends."""
+        writer.append("a.py", "f1", [])
+        writer.append("b.py", "f1", [])
+        writer.append("c.py", "f2", [])
+        assert writer._entry_count == 3
+
+
+class TestPartialResultsCommit:
+    """Tests for the commit method (clean completion)."""
+
+    def test_commit_deletes_partial_file(self, writer):
+        """Clean completion removes the partial results file."""
+        writer.append("a.py", "frame_1", [])
+        assert writer.path.exists()
+
+        writer.commit()
+        assert not writer.path.exists()
+
+    def test_commit_resets_entry_count(self, writer):
+        """Entry count is zeroed after commit."""
+        writer.append("a.py", "f1", [])
+        writer.commit()
+        assert writer._entry_count == 0
+
+    def test_commit_without_appends_is_safe(self, writer):
+        """Committing without any appends is a no-op."""
+        writer.commit()  # Should not raise
+
+
+class TestPartialResultsResume:
+    """Tests for resume support: load_completed_keys."""
+
+    def test_load_completed_keys_returns_set_of_tuples(self, writer, project_root):
+        """Completed keys are (frame_id, file_path) tuples."""
+        writer.append("src/a.py", "security_frame", [])
+        writer.append("src/b.py", "quality_frame", [{"id": "Q-1"}])
+        writer.close()
+
+        keys = PartialResultsWriter.load_completed_keys(project_root)
+        assert ("security_frame", "src/a.py") in keys
+        assert ("quality_frame", "src/b.py") in keys
+        assert len(keys) == 2
+
+    def test_load_completed_keys_empty_when_no_file(self, project_root):
+        """No partial results file returns empty set."""
+        keys = PartialResultsWriter.load_completed_keys(project_root)
+        assert keys == set()
+
+    def test_load_completed_keys_skips_bad_lines(self, writer, project_root):
+        """Malformed JSON lines are skipped gracefully."""
+        writer.append("good.py", "f1", [])
+        writer.close()
+
+        # Inject a bad line
+        with open(writer.path, "a") as f:
+            f.write("NOT VALID JSON\n")
+
+        writer2 = PartialResultsWriter(
+            project_root=project_root, install_signal_handlers=False,
+        )
+        writer2.append("also_good.py", "f2", [])
+        writer2.close()
+
+        keys = PartialResultsWriter.load_completed_keys(project_root)
+        assert ("f1", "good.py") in keys
+        assert ("f2", "also_good.py") in keys
+
+    def test_has_partial_results_true_when_file_exists(self, writer, project_root):
+        """has_partial_results returns True when file exists with content."""
+        writer.append("a.py", "f1", [])
+        writer.close()
+
+        assert PartialResultsWriter.has_partial_results(project_root) is True
+
+    def test_has_partial_results_false_when_missing(self, project_root):
+        """has_partial_results returns False when no file exists."""
+        assert PartialResultsWriter.has_partial_results(project_root) is False
+
+
+class TestPartialResultsLoadFindings:
+    """Tests for loading findings from partial results."""
+
+    def test_load_findings_returns_flat_list(self, writer, project_root):
+        """Findings from all lines are merged into a flat list."""
+        writer.append("a.py", "f1", [
+            {"id": "F-001", "severity": "high", "message": "Issue 1"},
+        ])
+        writer.append("b.py", "f1", [
+            {"id": "F-002", "severity": "medium", "message": "Issue 2"},
+            {"id": "F-003", "severity": "low", "message": "Issue 3"},
+        ])
+        writer.append("c.py", "f2", [])  # clean file
+        writer.close()
+
+        findings = PartialResultsWriter.load_findings(project_root)
+        assert len(findings) == 3
+        ids = {f["id"] for f in findings}
+        assert ids == {"F-001", "F-002", "F-003"}
+
+    def test_load_findings_empty_when_no_file(self, project_root):
+        """Returns empty list when no partial results exist."""
+        findings = PartialResultsWriter.load_findings(project_root)
+        assert findings == []
+
+
+class TestPartialResultsFlush:
+    """Tests for flush and close behaviour."""
+
+    def test_flush_is_safe_before_any_append(self, writer):
+        """Flush before any writes does not raise."""
+        writer.flush()
+
+    def test_close_is_idempotent(self, writer):
+        """Closing twice does not raise."""
+        writer.append("a.py", "f1", [])
+        writer.close()
+        writer.close()  # Should not raise
+
+    def test_path_property(self, writer, project_root):
+        """Path property returns the expected JSONL path."""
+        expected = project_root / _DEFAULT_PARTIAL_DIR / _DEFAULT_PARTIAL_FILENAME
+        assert writer.path == expected
+
+
+class TestPartialResultsDirectoryCreation:
+    """Tests for directory creation behaviour."""
+
+    def test_creates_cache_directory(self, tmp_path):
+        """Writer creates .warden/cache/ directory if missing."""
+        root = tmp_path / "fresh_project"
+        root.mkdir()
+
+        w = PartialResultsWriter(
+            project_root=root, install_signal_handlers=False,
+        )
+        assert (root / _DEFAULT_PARTIAL_DIR).is_dir()
+        w.close()


### PR DESCRIPTION
## Summary
- **#100 Process isolation per file**: Wraps tree-sitter AST parsing in `ProcessPoolExecutor` so that a single-file crash (segfault, OOM in native code) cannot kill the entire scan. Worker crashes are caught and recorded as `failed` in stats; remaining files continue parsing normally. The pool is re-created after a broken worker to avoid cascading failures.
- **#101 Partial scan results to disk**: Adds `PartialResultsWriter` that appends findings to `.warden/cache/partial_results.jsonl` after each file's frame execution completes. On clean scan completion the file is deleted. SIGINT/SIGTERM handlers flush the current buffer before exit.
- **`--resume` CLI flag**: When `partial_results.jsonl` exists, already-scanned `(frame_id, file_path)` pairs are skipped, allowing interrupted scans to resume from where they left off.

## Changed files
- `src/warden/pipeline/application/orchestrator/ast_pre_parser.py` -- ProcessPoolExecutor wrapper with crash recovery
- `src/warden/pipeline/application/orchestrator/partial_results_writer.py` -- New JSONL append-only writer with signal handlers
- `src/warden/pipeline/application/orchestrator/frame_runner.py` -- Integrates partial results persistence after each file execution
- `src/warden/cli/commands/scan.py` -- Adds `--resume` flag and plumbs it through to `_run_scan_async`
- `tests/pipeline/application/orchestrator/test_ast_pre_parser.py` -- 18 tests (updated + new process isolation tests)
- `tests/pipeline/application/orchestrator/test_partial_results_writer.py` -- 18 new tests for JSONL writer, resume, and commit

## Test plan
- [x] All 58 existing + new tests pass (`pytest -k "ast_pre or frame_runner or partial_results"`)
- [ ] Manual: run `warden scan`, interrupt with Ctrl+C, verify `.warden/cache/partial_results.jsonl` exists
- [ ] Manual: run `warden scan --resume`, verify skipped file count matches partial results
- [ ] Manual: full clean scan completes and deletes `partial_results.jsonl`

Closes #100, Closes #101