### PR TITLE
feat(taint): interprocedural tracking + multi-label taint (#74, #75)

### DIFF
--- a/src/warden/validation/frames/security/_internal/taint_analyzer.py
+++ b/src/warden/validation/frames/security/_internal/taint_analyzer.py
@@ -2,12 +2,17 @@
 Source-to-Sink Taint Analysis Engine.
 
 Supports:
-  - Python: AST-based, single-function scope
+  - Python: AST-based, interprocedural (single-file) with multi-label taint
   - JavaScript/TypeScript: Regex-based, multi-pass propagation
   - Go: Regex-based, 3-pass propagation
   - Java: Regex-based, 3-pass propagation
 
-Cross-function and cross-file analysis deferred to future iterations.
+Phase 1 interprocedural analysis tracks taint across function boundaries
+within a single file via call-graph construction and return-value propagation.
+
+Multi-label taint assigns per-sink-type labels (e.g. {"SQL-value", "HTML-content"})
+to tainted variables.  Sanitizers remove specific labels; a variable is clean
+only when its label set is empty.
 """
 
 from __future__ import annotations
@@ -28,7 +33,7 @@ logger = get_logger(__name__)
 
 # ── Single source of truth for taint configuration defaults ────────────────
 TAINT_DEFAULTS: dict[str, float] = {
-    "confidence_threshold": 0.8,  # >= this → HIGH severity + is_blocker
+    "confidence_threshold": 0.8,  # >= this -> HIGH severity + is_blocker
     "sanitizer_penalty": 0.3,  # multiplied when sanitized (0.0-1.0)
     "propagation_confidence": 0.75,  # confidence assigned to propagated taint
     "signal_base_source": 0.65,  # heuristic source detection base
@@ -54,7 +59,7 @@ def validate_taint_config(raw: dict[str, Any] | None) -> dict[str, float]:
             validated[key] = default
             continue
 
-        # Type coercion — accept int/float, reject everything else
+        # Type coercion -- accept int/float, reject everything else
         try:
             val = float(raw_val)
         except (TypeError, ValueError):
@@ -91,6 +96,7 @@ class TaintSource:
     node_type: str  # "call", "attribute", "subscript"
     line: int
     confidence: float = 0.9
+    taint_labels: set[str] = field(default_factory=set)  # {"SQL-value", "HTML-content", ...}
 
 
 @dataclass
@@ -104,14 +110,79 @@ class TaintSink:
 
 @dataclass
 class TaintPath:
-    """A detected taint flow from source to sink."""
+    """A detected taint flow from source to sink.
+
+    Multi-label taint: ``taint_labels`` holds the set of sink-type labels that
+    are still active (not yet sanitized) at the point the tainted data reaches
+    the sink.  ``is_sanitized`` is now a computed property -- True when the
+    sink's own type has been removed from the label set (or when sanitizers
+    were applied that cover the sink type).
+
+    For backward compatibility, ``is_sanitized`` can still be passed to
+    ``__init__`` as a bool.  When explicitly set to ``True`` the label set
+    will be empty, matching legacy behaviour.
+    """
 
     source: TaintSource
     sink: TaintSink
     transformations: list[str] = field(default_factory=list)  # ["f-string", "str.format"]
     sanitizers: list[str] = field(default_factory=list)  # ["html.escape"]
-    is_sanitized: bool = False
+    taint_labels: set[str] = field(default_factory=set)  # active (unsanitized) labels
     confidence: float = 0.0
+
+    # Private backing field for legacy is_sanitized support.
+    # When someone passes is_sanitized=True in constructor, we store it
+    # and use it as override.  Otherwise computed from taint_labels.
+    _is_sanitized_override: bool | None = field(default=None, repr=False, compare=False)
+
+    def __init__(
+        self,
+        source: TaintSource,
+        sink: TaintSink,
+        transformations: list[str] | None = None,
+        sanitizers: list[str] | None = None,
+        is_sanitized: bool | None = None,
+        taint_labels: set[str] | None = None,
+        confidence: float = 0.0,
+    ) -> None:
+        self.source = source
+        self.sink = sink
+        self.transformations = transformations if transformations is not None else []
+        self.sanitizers = sanitizers if sanitizers is not None else []
+        self.confidence = confidence
+
+        # Multi-label taint: if explicit taint_labels given, use them.
+        # Otherwise derive from is_sanitized for backward compatibility.
+        if taint_labels is not None:
+            self.taint_labels = set(taint_labels)
+        elif is_sanitized:
+            # Legacy: explicitly sanitized -> empty label set
+            self.taint_labels = set()
+        else:
+            # Default: the sink's own type is the active label
+            self.taint_labels = {sink.sink_type}
+
+        # Store legacy override for backward-compat property
+        if is_sanitized is not None:
+            self._is_sanitized_override = is_sanitized
+        else:
+            self._is_sanitized_override = None
+
+    @property
+    def is_sanitized(self) -> bool:
+        """Whether the taint flow is sanitized for the target sink type.
+
+        A flow is sanitized when:
+          1. Legacy override was explicitly set to True, OR
+          2. The sink's type is not in the active taint_labels set
+             (meaning a sanitizer removed it).
+
+        An empty taint_labels set means fully sanitized.
+        """
+        if self._is_sanitized_override is not None:
+            return self._is_sanitized_override
+        # If sink type is no longer in taint_labels, it's been sanitized
+        return self.sink.sink_type not in self.taint_labels
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -120,6 +191,7 @@ class TaintPath:
             "transformations": self.transformations,
             "sanitizers": self.sanitizers,
             "is_sanitized": self.is_sanitized,
+            "taint_labels": sorted(self.taint_labels),
             "confidence": self.confidence,
         }
 
@@ -172,7 +244,7 @@ TAINT_SINKS: dict[str, str] = {
     # File sinks
     "open": "FILE-path",
     "pathlib.Path": "FILE-path",
-    # HTTP / SSRF sinks (CWE-918) — user-controlled URLs sent to external services
+    # HTTP / SSRF sinks (CWE-918) -- user-controlled URLs sent to external services
     "requests.get": "HTTP-request",
     "requests.post": "HTTP-request",
     "requests.put": "HTTP-request",
@@ -274,7 +346,7 @@ JS_TAINT_SINKS: dict[str, str] = {
     "client.query": "SQL-value",
     "sequelize.query": "SQL-value",
     "knex.raw": "SQL-value",
-    # HTML / XSS — property assignment sinks handled separately
+    # HTML / XSS -- property assignment sinks handled separately
     "innerHTML": "HTML-content",
     "outerHTML": "HTML-content",
     "document.write": "HTML-content",
@@ -341,15 +413,55 @@ _RE_DESTRUCT = re.compile(r"(?:const|let|var)\s+\{([^}]+)\}\s*=\s*(.+?)(?:;|$)")
 # Matches template literal holes: ${varName}
 _RE_TEMPLATE = re.compile(r"\$\{(\w+)\}")
 
+# ── All known sink types (used to build initial taint label sets) ──────────
+ALL_SINK_TYPES: set[str] = {
+    "SQL-value",
+    "CMD-argument",
+    "HTML-content",
+    "CODE-execution",
+    "FILE-path",
+    "HTTP-request",
+}
+
+
+# ── Interprocedural helper dataclass ───────────────────────────────────────
+
+@dataclass
+class _FunctionSummary:
+    """Summary of taint-relevant information for a single function.
+
+    Built during the first pass of interprocedural analysis.
+    """
+    name: str
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+    param_names: list[str] = field(default_factory=list)
+    # Which parameter indices receive taint when called with tainted args
+    tainted_params: dict[int, TaintSource] = field(default_factory=dict)
+    # Whether the function returns tainted data (and which source)
+    returns_taint: TaintSource | None = None
+    # Taint labels associated with the return value
+    return_taint_labels: set[str] = field(default_factory=set)
+    # Internal taint paths found within this function
+    paths: list[TaintPath] = field(default_factory=list)
+
 
 class TaintAnalyzer:
     """
     Multi-language source-to-sink taint analyzer.
 
-    - Python: AST-based, single-function scope
+    - Python: AST-based, interprocedural (single-file) with multi-label taint
     - JavaScript/TypeScript: Regex-based, multi-pass propagation
 
-    Cross-function and cross-file analysis deferred to future iterations.
+    Interprocedural analysis (Python only, Phase 1 -- single-file):
+      1. Build a function summary for each function in the file.
+      2. Build a call graph from function calls within the file.
+      3. Propagate taint from callers to callees (argument -> parameter).
+      4. Propagate taint from callee return values back to callers.
+
+    Multi-label taint:
+      Each tainted variable carries a set of sink-type labels.
+      Sanitizers remove specific labels from the set.
+      A variable is clean only when its label set is empty.
 
     Args:
         catalog: TaintCatalog instance with sources/sinks/sanitizers.
@@ -375,7 +487,7 @@ class TaintAnalyzer:
         if overrides:
             logger.info("taint_config_custom_overrides", overrides=overrides)
 
-        # Load signal inference engine (graceful — unavailable if signals.yaml missing)
+        # Load signal inference engine (graceful -- unavailable if signals.yaml missing)
         try:
             from warden.validation.frames.security._internal.model_loader import (
                 ModelPackLoader,
@@ -422,16 +534,227 @@ class TaintAnalyzer:
             logger.debug("taint_analysis_parse_error", error=str(e))
             return []
 
-        paths: list[TaintPath] = []
-
-        # Analyze each function definition
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                func_paths = self._analyze_function(node, source_code)
-                paths.extend(func_paths)
+        paths = self._analyze_python_interprocedural(tree, source_code)
 
         logger.debug("taint_analysis_complete", paths_found=len(paths))
         return paths
+
+    # ── Python interprocedural analysis ────────────────────────────────────
+
+    def _analyze_python_interprocedural(self, tree: ast.Module, source_code: str) -> list[TaintPath]:
+        """Interprocedural taint analysis across all functions in a single file.
+
+        Phase 1 algorithm:
+          1. Collect all function definitions and build summaries.
+          2. First pass: analyze each function in isolation (intra-procedural).
+          3. Build call graph: for each call to a known function in the file,
+             propagate taint from caller arguments to callee parameters.
+          4. Re-analyze functions whose parameters gained new taint.
+          5. Propagate return-value taint back to callers.
+          6. Iterate until fixpoint (max 5 rounds).
+        """
+        # Step 1: Collect all top-level and nested function definitions
+        func_nodes: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                func_nodes.append(node)
+
+        if not func_nodes:
+            return []
+
+        # Build name -> summary mapping
+        summaries: dict[str, _FunctionSummary] = {}
+        for func_node in func_nodes:
+            param_names = self._extract_param_names(func_node)
+            summary = _FunctionSummary(
+                name=func_node.name,
+                node=func_node,
+                param_names=param_names,
+            )
+            summaries[func_node.name] = summary
+
+        # Step 2: First pass -- analyze each function in isolation
+        # Track tainted variables at the file level for interprocedural sharing.
+        # Each function gets its own tainted_vars, but we also maintain a
+        # "function return taint" map for cross-function propagation.
+        file_tainted_vars: dict[str, TaintSource] = {}
+        # Map: function_name -> tainted_vars dict used during analysis
+        func_tainted_vars: dict[str, dict[str, TaintSource]] = {}
+        # Map: function_name -> taint_labels for each tainted var
+        func_taint_labels: dict[str, dict[str, set[str]]] = {}
+
+        all_paths: list[TaintPath] = []
+
+        for fname, summary in summaries.items():
+            tainted_vars: dict[str, TaintSource] = {}
+            taint_labels: dict[str, set[str]] = {}
+            paths = self._analyze_function_multilabel(
+                summary.node, source_code, tainted_vars, taint_labels
+            )
+            summary.paths = paths
+            func_tainted_vars[fname] = tainted_vars
+            func_taint_labels[fname] = taint_labels
+
+            # Check if function returns tainted data
+            ret_source, ret_labels = self._check_function_returns(
+                summary.node, tainted_vars, taint_labels
+            )
+            if ret_source:
+                summary.returns_taint = ret_source
+                summary.return_taint_labels = ret_labels
+
+        # Step 3-6: Interprocedural propagation (fixpoint loop)
+        for _round in range(5):
+            changed = False
+
+            for fname, summary in summaries.items():
+                tainted_vars = func_tainted_vars[fname]
+                taint_labels = func_taint_labels[fname]
+
+                # Scan calls within this function to other file-local functions
+                for node in ast.walk(summary.node):
+                    if not isinstance(node, ast.Call):
+                        continue
+
+                    callee_name = self._get_dotted_name(node.func)
+                    if not callee_name:
+                        continue
+
+                    # Resolve method calls: self.process(...) -> process
+                    # Also handles direct calls: process(...)
+                    resolved_name = callee_name
+                    if resolved_name not in summaries:
+                        # Try the last segment for method calls (self.foo -> foo)
+                        last_segment = resolved_name.rsplit('.', 1)[-1]
+                        if last_segment in summaries:
+                            resolved_name = last_segment
+                        else:
+                            continue
+
+                    callee = summaries[resolved_name]
+
+                    # Propagate: caller's tainted args -> callee's params
+                    for i, arg in enumerate(node.args):
+                        if i >= len(callee.param_names):
+                            break
+                        tainted_source = self._is_tainted(arg, tainted_vars)
+                        if tainted_source:
+                            param_name = callee.param_names[i]
+                            callee_vars = func_tainted_vars[resolved_name]
+                            callee_labels = func_taint_labels[resolved_name]
+                            if param_name not in callee_vars:
+                                # Propagate taint to callee parameter
+                                callee_vars[param_name] = TaintSource(
+                                    name=tainted_source.name,
+                                    node_type="interprocedural-arg",
+                                    line=tainted_source.line,
+                                    confidence=tainted_source.confidence * self._propagation_confidence,
+                                    taint_labels=set(tainted_source.taint_labels) if tainted_source.taint_labels else set(ALL_SINK_TYPES),
+                                )
+                                # Propagate labels
+                                arg_var_name = self._get_var_name(arg)
+                                if arg_var_name and arg_var_name in taint_labels:
+                                    callee_labels[param_name] = set(taint_labels[arg_var_name])
+                                else:
+                                    callee_labels[param_name] = set(ALL_SINK_TYPES)
+                                changed = True
+
+                    # Propagate: callee's return taint -> caller's assignment
+                    if callee.returns_taint:
+                        # Find the assignment target: x = callee_func(...)
+                        assign_target = self._find_call_assignment_target(
+                            summary.node, node
+                        )
+                        if assign_target and assign_target not in tainted_vars:
+                            tainted_vars[assign_target] = TaintSource(
+                                name=f"{resolved_name}()",
+                                node_type="interprocedural-return",
+                                line=getattr(node, "lineno", 0),
+                                confidence=callee.returns_taint.confidence * self._propagation_confidence,
+                                taint_labels=set(callee.return_taint_labels) if callee.return_taint_labels else set(ALL_SINK_TYPES),
+                            )
+                            taint_labels[assign_target] = (
+                                set(callee.return_taint_labels)
+                                if callee.return_taint_labels
+                                else set(ALL_SINK_TYPES)
+                            )
+                            changed = True
+
+            if not changed:
+                break
+
+            # Re-analyze functions that gained new taint
+            for fname, summary in summaries.items():
+                tainted_vars = func_tainted_vars[fname]
+                taint_labels = func_taint_labels[fname]
+                paths = self._analyze_function_multilabel(
+                    summary.node, source_code, tainted_vars, taint_labels
+                )
+                summary.paths = paths
+
+                # Re-check return taint
+                ret_source, ret_labels = self._check_function_returns(
+                    summary.node, tainted_vars, taint_labels
+                )
+                if ret_source:
+                    summary.returns_taint = ret_source
+                    summary.return_taint_labels = ret_labels
+
+        # Collect all paths from all functions
+        for summary in summaries.values():
+            all_paths.extend(summary.paths)
+
+        return all_paths
+
+    def _extract_param_names(self, func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+        """Extract parameter names from a function definition."""
+        params: list[str] = []
+        for arg in func_node.args.args:
+            if arg.arg != "self" and arg.arg != "cls":
+                params.append(arg.arg)
+        return params
+
+    def _check_function_returns(
+        self,
+        func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+        tainted_vars: dict[str, TaintSource],
+        taint_labels: dict[str, set[str]],
+    ) -> tuple[TaintSource | None, set[str]]:
+        """Check if a function returns tainted data.
+
+        Returns (TaintSource, taint_labels) if the return value is tainted,
+        or (None, set()) otherwise.
+        """
+        for node in ast.walk(func_node):
+            if isinstance(node, ast.Return) and node.value is not None:
+                tainted = self._is_tainted(node.value, tainted_vars)
+                if tainted:
+                    var_name = self._get_var_name(node.value)
+                    labels = set()
+                    if var_name and var_name in taint_labels:
+                        labels = set(taint_labels[var_name])
+                    elif tainted.taint_labels:
+                        labels = set(tainted.taint_labels)
+                    else:
+                        labels = set(ALL_SINK_TYPES)
+                    return tainted, labels
+        return None, set()
+
+    def _find_call_assignment_target(
+        self,
+        func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+        call_node: ast.Call,
+    ) -> str | None:
+        """Find the variable name assigned from a call expression.
+
+        Given `x = some_func(...)`, returns "x".
+        """
+        for node in ast.walk(func_node):
+            if isinstance(node, ast.Assign):
+                if node.value is call_node:
+                    if len(node.targets) == 1:
+                        return self._get_var_name(node.targets[0])
+        return None
 
     # ── JavaScript / TypeScript analysis ───────────────────────────────────
 
@@ -479,7 +802,12 @@ class TaintAnalyzer:
             for src in self._catalog.sources.get("javascript", set()):
                 if src in value_expr:
                     if var_name not in tainted_vars:
-                        tainted_vars[var_name] = TaintSource(name=value_expr, node_type="assignment", line=line_num)
+                        tainted_vars[var_name] = TaintSource(
+                            name=value_expr,
+                            node_type="assignment",
+                            line=line_num,
+                            taint_labels=set(ALL_SINK_TYPES),
+                        )
                     break
 
         # Destructuring: const { id, name } = req.body
@@ -488,14 +816,15 @@ class TaintAnalyzer:
             for src in self._catalog.sources.get("javascript", set()):
                 if src in value_expr:
                     for raw_field in m.group(1).split(","):
-                        # Support `{ a: b }` rename — take the alias (b)
+                        # Support `{ a: b }` rename -- take the alias (b)
                         parts = raw_field.strip().split(":")
-                        field = parts[-1].strip()
-                        if field and field not in tainted_vars:
-                            tainted_vars[field] = TaintSource(
-                                name=f"{value_expr}.{field}",
+                        field_name = parts[-1].strip()
+                        if field_name and field_name not in tainted_vars:
+                            tainted_vars[field_name] = TaintSource(
+                                name=f"{value_expr}.{field_name}",
                                 node_type="destructuring",
                                 line=line_num,
+                                taint_labels=set(ALL_SINK_TYPES),
                             )
                     break
 
@@ -510,11 +839,13 @@ class TaintAnalyzer:
                 continue
             for tv in tainted_vars:
                 if re.search(r"\b" + re.escape(tv) + r"\b", value_expr):
+                    parent_labels = tainted_vars[tv].taint_labels
                     tainted_vars[var_name] = TaintSource(
                         name=value_expr,
                         node_type="propagation",
                         line=line_num,
                         confidence=self._propagation_confidence,
+                        taint_labels=set(parent_labels) if parent_labels else set(ALL_SINK_TYPES),
                     )
                     added = True
                     break
@@ -529,7 +860,7 @@ class TaintAnalyzer:
         paths: list[TaintPath] = []
 
         for sink_name, sink_type in self._catalog.sinks.items():
-            # ── Assignment-style sinks: element.innerHTML = taintedVar ──
+            # -- Assignment-style sinks: element.innerHTML = taintedVar --
             if sink_name in self._catalog.assign_sinks:
                 pattern = re.compile(r"\." + re.escape(sink_name) + r"\s*=\s*(.+?)(?:;|$)")
                 for m in pattern.finditer(stripped):
@@ -537,7 +868,7 @@ class TaintAnalyzer:
                     paths.extend(self._js_check_args(args_str, sink_name, sink_type, line_num, tainted_vars))
                 continue
 
-            # ── Call-style sinks: db.query(...), eval(...) ──
+            # -- Call-style sinks: db.query(...), eval(...) --
             # Match both `sinkName(` and `obj.sinkName(` / `obj.sinkName\n(`
             escaped = re.escape(sink_name)
             call_pat = re.compile(r"(?:^|[^.\w])" + escaped + r"\s*\(([^)]*)\)")
@@ -562,7 +893,11 @@ class TaintAnalyzer:
         for tv, tainted_src in tainted_vars.items():
             if re.search(r"\b" + re.escape(tv) + r"\b", args_str):
                 sanitizers = self._detect_js_sanitizers(args_str, sink_type)
-                is_sanitized = len(sanitizers) > 0
+                # Multi-label: compute remaining labels after sanitization
+                active_labels = set(tainted_src.taint_labels) if tainted_src.taint_labels else set(ALL_SINK_TYPES)
+                if sanitizers:
+                    active_labels.discard(sink_type)
+                is_sanitized = sink_type not in active_labels
                 confidence = tainted_src.confidence * (self._sanitizer_penalty if is_sanitized else 1.0)
                 found.append(
                     TaintPath(
@@ -570,6 +905,7 @@ class TaintAnalyzer:
                         sink=TaintSink(name=sink_name, sink_type=sink_type, line=line_num),
                         sanitizers=sanitizers,
                         is_sanitized=is_sanitized,
+                        taint_labels=active_labels,
                         confidence=confidence,
                     )
                 )
@@ -583,25 +919,41 @@ class TaintAnalyzer:
                 sanitizers.append(san)
         return sanitizers
 
-    # ── Python AST analysis ─────────────────────────────────────────────────
+    # ── Python AST analysis (multi-label) ──────────────────────────────────
 
-    def _analyze_function(self, func_node: ast.FunctionDef | ast.AsyncFunctionDef, source: str) -> list[TaintPath]:
-        """Analyze a single function for taint flows."""
-        # Step 1: Find all tainted variables (assigned from sources)
-        tainted_vars: dict[str, TaintSource] = {}
-        # Step 2: Track transformations on tainted data
+    def _analyze_function_multilabel(
+        self,
+        func_node: ast.FunctionDef | ast.AsyncFunctionDef,
+        source: str,
+        tainted_vars: dict[str, TaintSource],
+        taint_labels: dict[str, set[str]],
+    ) -> list[TaintPath]:
+        """Analyze a single function for taint flows with multi-label tracking.
+
+        Args:
+            func_node: The function AST node.
+            source: Full source code string.
+            tainted_vars: Mutable dict of variable name -> TaintSource.
+                          Pre-populated with interprocedural taint.
+            taint_labels: Mutable dict of variable name -> set of active
+                          sink-type labels.  Pre-populated with interprocedural labels.
+
+        Returns:
+            List of detected TaintPath objects.
+        """
+        # Track transformations on tainted data
         transformations: dict[str, list[str]] = {}
-        # Step 3: Find sinks consuming tainted data
+        # Find sinks consuming tainted data
         paths: list[TaintPath] = []
 
         for node in ast.walk(func_node):
             # Detect taint sources in assignments
             if isinstance(node, ast.Assign):
-                self._check_assignment_for_sources(node, tainted_vars)
+                self._check_assignment_for_sources_multilabel(node, tainted_vars, taint_labels)
 
             # Detect taint in augmented assignments
             if isinstance(node, ast.AugAssign):
-                self._check_aug_assignment(node, tainted_vars)
+                self._check_aug_assignment_multilabel(node, tainted_vars, taint_labels)
 
             # Detect sinks
             if isinstance(node, ast.Call):
@@ -617,12 +969,25 @@ class TaintAnalyzer:
                                 line=node.lineno,
                             )
 
-                            # Check for sanitizers
+                            # Check for sanitizers (per-sink-type)
                             sanitizers = self._detect_sanitizers(arg, sink.sink_type)
-                            is_sanitized = len(sanitizers) > 0
+
+                            # Multi-label: compute active labels
+                            var_name = self._get_var_name(arg)
+                            if var_name and var_name in taint_labels:
+                                active_labels = set(taint_labels[var_name])
+                            elif tainted_source.taint_labels:
+                                active_labels = set(tainted_source.taint_labels)
+                            else:
+                                active_labels = set(ALL_SINK_TYPES)
+
+                            # Sanitizers remove specific labels
+                            if sanitizers:
+                                active_labels.discard(sink.sink_type)
+
+                            is_sanitized = sink.sink_type not in active_labels
 
                             # Get transformations
-                            var_name = self._get_var_name(arg)
                             xforms = transformations.get(var_name, []) if var_name else []
 
                             confidence = tainted_source.confidence
@@ -635,6 +1000,7 @@ class TaintAnalyzer:
                                 transformations=xforms,
                                 sanitizers=sanitizers,
                                 is_sanitized=is_sanitized,
+                                taint_labels=active_labels,
                                 confidence=confidence,
                             )
                             paths.append(path)
@@ -665,14 +1031,24 @@ class TaintAnalyzer:
 
         return paths
 
-    def _check_assignment_for_sources(self, node: ast.Assign, tainted_vars: dict[str, TaintSource]) -> None:
-        """Check if an assignment introduces tainted data."""
+    def _check_assignment_for_sources_multilabel(
+        self,
+        node: ast.Assign,
+        tainted_vars: dict[str, TaintSource],
+        taint_labels: dict[str, set[str]],
+    ) -> None:
+        """Check if an assignment introduces tainted data (multi-label aware)."""
         source = self._identify_source(node.value)
         if source:
             for target in node.targets:
                 var_name = self._get_var_name(target)
                 if var_name:
                     tainted_vars[var_name] = source
+                    # New source -> all sink types are potential labels
+                    if source.taint_labels:
+                        taint_labels[var_name] = set(source.taint_labels)
+                    else:
+                        taint_labels[var_name] = set(ALL_SINK_TYPES)
 
         # Propagate taint through assignments: x = tainted_var
         if not source:
@@ -682,9 +1058,47 @@ class TaintAnalyzer:
                     var_name = self._get_var_name(target)
                     if var_name:
                         tainted_vars[var_name] = tainted
+                        # Inherit labels from the source variable
+                        src_var = self._get_var_name(node.value)
+                        if src_var and src_var in taint_labels:
+                            taint_labels[var_name] = set(taint_labels[src_var])
+                        elif tainted.taint_labels:
+                            taint_labels[var_name] = set(tainted.taint_labels)
+                        else:
+                            taint_labels[var_name] = set(ALL_SINK_TYPES)
 
-    def _check_aug_assignment(self, node: ast.AugAssign, tainted_vars: dict[str, TaintSource]) -> None:
-        """Check augmented assignments (+=, etc.) for taint propagation."""
+                        # Check if the RHS passes through a sanitizer
+                        self._apply_sanitizer_labels(
+                            node.value, var_name, taint_labels
+                        )
+
+    def _apply_sanitizer_labels(
+        self,
+        node: ast.expr,
+        var_name: str,
+        taint_labels: dict[str, set[str]],
+    ) -> None:
+        """If the expression passes through a sanitizer call, remove the
+        corresponding label from the variable's taint_labels."""
+        if not isinstance(node, ast.Call):
+            return
+        func_name = self._get_dotted_name(node.func)
+        if not func_name:
+            return
+
+        for sink_type, sanitizer_set in self._catalog.sanitizers.items():
+            for san in sanitizer_set:
+                if san in func_name:
+                    if var_name in taint_labels:
+                        taint_labels[var_name].discard(sink_type)
+
+    def _check_aug_assignment_multilabel(
+        self,
+        node: ast.AugAssign,
+        tainted_vars: dict[str, TaintSource],
+        taint_labels: dict[str, set[str]],
+    ) -> None:
+        """Check augmented assignments (+=, etc.) for taint propagation (multi-label)."""
         var_name = self._get_var_name(node.target)
         if var_name and var_name in tainted_vars:
             return  # Already tainted
@@ -692,6 +1106,31 @@ class TaintAnalyzer:
         source = self._identify_source(node.value)
         if source and var_name:
             tainted_vars[var_name] = source
+            if source.taint_labels:
+                taint_labels[var_name] = set(source.taint_labels)
+            else:
+                taint_labels[var_name] = set(ALL_SINK_TYPES)
+
+    # ── Legacy single-function analysis (kept for reference/fallback) ──────
+
+    def _analyze_function(self, func_node: ast.FunctionDef | ast.AsyncFunctionDef, source: str) -> list[TaintPath]:
+        """Analyze a single function for taint flows (legacy, non-multi-label).
+
+        Delegates to the new multi-label implementation with fresh state.
+        """
+        tainted_vars: dict[str, TaintSource] = {}
+        taint_labels: dict[str, set[str]] = {}
+        return self._analyze_function_multilabel(func_node, source, tainted_vars, taint_labels)
+
+    def _check_assignment_for_sources(self, node: ast.Assign, tainted_vars: dict[str, TaintSource]) -> None:
+        """Check if an assignment introduces tainted data (legacy wrapper)."""
+        taint_labels: dict[str, set[str]] = {}
+        self._check_assignment_for_sources_multilabel(node, tainted_vars, taint_labels)
+
+    def _check_aug_assignment(self, node: ast.AugAssign, tainted_vars: dict[str, TaintSource]) -> None:
+        """Check augmented assignments (+=, etc.) for taint propagation (legacy wrapper)."""
+        taint_labels: dict[str, set[str]] = {}
+        self._check_aug_assignment_multilabel(node, tainted_vars, taint_labels)
 
     def _identify_source(self, node: ast.expr) -> TaintSource | None:
         """Check if an expression is a known taint source."""
@@ -704,6 +1143,7 @@ class TaintAnalyzer:
                         name=name,
                         node_type=type(node).__name__.lower(),
                         line=getattr(node, "lineno", 0),
+                        taint_labels=set(ALL_SINK_TYPES),
                     )
 
         # Check for call to known source
@@ -716,6 +1156,7 @@ class TaintAnalyzer:
                             name=func_name,
                             node_type="call",
                             line=getattr(node, "lineno", 0),
+                            taint_labels=set(ALL_SINK_TYPES),
                         )
                 # Signal inference fallback for calls
                 if self._signal_engine and self._signal_engine.is_available():
@@ -728,6 +1169,7 @@ class TaintAnalyzer:
                             node_type="call",
                             line=getattr(node, "lineno", 0),
                             confidence=inferred[1],
+                            taint_labels=set(ALL_SINK_TYPES),
                         )
 
         # Check subscript (e.g., request.args['id'])
@@ -740,6 +1182,7 @@ class TaintAnalyzer:
                             name=value_name,
                             node_type="subscript",
                             line=getattr(node, "lineno", 0),
+                            taint_labels=set(ALL_SINK_TYPES),
                         )
                 # Signal inference fallback for subscript
                 if self._signal_engine and self._signal_engine.is_available():
@@ -752,6 +1195,7 @@ class TaintAnalyzer:
                             node_type="subscript",
                             line=getattr(node, "lineno", 0),
                             confidence=inferred[1],
+                            taint_labels=set(ALL_SINK_TYPES),
                         )
 
         # Signal inference fallback for attribute access
@@ -765,6 +1209,7 @@ class TaintAnalyzer:
                     node_type=type(node).__name__.lower(),
                     line=getattr(node, "lineno", 0),
                     confidence=inferred[1],
+                    taint_labels=set(ALL_SINK_TYPES),
                 )
 
         return None
@@ -773,7 +1218,7 @@ class TaintAnalyzer:
         """Check if a call is a known sink. Returns (name, sink_type) or None."""
         func_name = self._get_dotted_name(node.func)
         if func_name:
-            # Step 1: explicit catalog lookup — segment-aware matching to prevent
+            # Step 1: explicit catalog lookup -- segment-aware matching to prevent
             # false positives like "open" matching "urllib.request.urlopen".
             # Prefer longer (more specific) patterns by checking all, collecting best.
             best: tuple[str, str] | None = None
@@ -828,13 +1273,17 @@ class TaintAnalyzer:
             if right:
                 return right
 
-        # Check format calls: "...".format(tainted)
+        # Check function calls: taint flows through call arguments.
+        # Handles .format(tainted), html.escape(tainted), any_func(tainted), etc.
         if isinstance(node, ast.Call):
-            if isinstance(node.func, ast.Attribute) and node.func.attr == "format":
-                for arg in node.args:
-                    result = self._is_tainted(arg, tainted_vars)
-                    if result:
-                        return result
+            for arg in node.args:
+                result = self._is_tainted(arg, tainted_vars)
+                if result:
+                    return result
+            for kw in node.keywords:
+                result = self._is_tainted(kw.value, tainted_vars)
+                if result:
+                    return result
 
         return None
 

--- a/tests/validation/frames/security/test_taint_interprocedural_multilabel.py
+++ b/tests/validation/frames/security/test_taint_interprocedural_multilabel.py
@@ -1,0 +1,462 @@
+"""Tests for interprocedural taint tracking (#74) and multi-label taint (#75).
+
+Issue #74: Interprocedural (cross-function) taint tracking within a single file.
+Issue #75: Multi-label taint tracking with per-sink-type sanitization.
+"""
+
+import pytest
+
+from warden.validation.frames.security._internal.taint_analyzer import (
+    ALL_SINK_TYPES,
+    TaintAnalyzer,
+    TaintPath,
+    TaintSink,
+    TaintSource,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #75: Multi-label taint tracking
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestMultiLabelTaintPath:
+    """TaintPath multi-label dataclass behavior."""
+
+    def test_default_taint_labels_include_sink_type(self):
+        """When no explicit labels, the sink type is the active label."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(source=source, sink=sink, confidence=0.9)
+        assert "SQL-value" in path.taint_labels
+        assert path.is_sanitized is False
+
+    def test_explicit_empty_labels_means_sanitized(self):
+        """Explicit empty taint_labels means fully sanitized."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(source=source, sink=sink, taint_labels=set(), confidence=0.9)
+        assert path.is_sanitized is True
+
+    def test_is_sanitized_legacy_override_true(self):
+        """Legacy is_sanitized=True still works."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source, sink=sink, is_sanitized=True, confidence=0.27
+        )
+        assert path.is_sanitized is True
+        # Legacy override -> empty label set
+        assert len(path.taint_labels) == 0
+
+    def test_is_sanitized_legacy_override_false(self):
+        """Legacy is_sanitized=False still works."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source, sink=sink, is_sanitized=False, confidence=0.9
+        )
+        assert path.is_sanitized is False
+        # Sink type should be in the label set
+        assert "SQL-value" in path.taint_labels
+
+    def test_taint_labels_with_multiple_types(self):
+        """A variable can carry multiple sink-type labels."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source,
+            sink=sink,
+            taint_labels={"SQL-value", "HTML-content", "CMD-argument"},
+            confidence=0.9,
+        )
+        assert "SQL-value" in path.taint_labels
+        assert "HTML-content" in path.taint_labels
+        assert path.is_sanitized is False
+
+    def test_removing_sink_type_from_labels_makes_sanitized(self):
+        """Removing the sink's own type from labels marks it as sanitized."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        # All labels except SQL-value
+        path = TaintPath(
+            source=source,
+            sink=sink,
+            taint_labels={"HTML-content", "CMD-argument"},
+            confidence=0.9,
+        )
+        assert path.is_sanitized is True
+
+    def test_to_json_includes_taint_labels(self):
+        """to_json output includes sorted taint_labels."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source,
+            sink=sink,
+            taint_labels={"SQL-value", "HTML-content"},
+            confidence=0.9,
+        )
+        j = path.to_json()
+        assert "taint_labels" in j
+        assert j["taint_labels"] == ["HTML-content", "SQL-value"]
+
+    def test_taint_source_carries_labels(self):
+        """TaintSource dataclass carries taint_labels."""
+        src = TaintSource(
+            name="request.args",
+            node_type="attribute",
+            line=1,
+            taint_labels={"SQL-value", "CMD-argument"},
+        )
+        assert "SQL-value" in src.taint_labels
+        assert "CMD-argument" in src.taint_labels
+
+    def test_taint_source_default_labels_empty(self):
+        """TaintSource default taint_labels is empty set."""
+        src = TaintSource(name="request.args", node_type="attribute", line=1)
+        assert src.taint_labels == set()
+
+
+class TestMultiLabelAnalysis:
+    """Integration: multi-label analysis detects label-aware paths."""
+
+    def setup_method(self):
+        self.analyzer = TaintAnalyzer()
+
+    def test_html_sanitizer_removes_html_label_only(self):
+        """html.escape removes HTML-content but not SQL-value label."""
+        code = '''
+def handler():
+    user_input = request.args.get('q')
+    safe_html = html.escape(user_input)
+    render_template_string(safe_html)
+'''
+        paths = self.analyzer.analyze(code)
+        # The path to render_template_string should be sanitized for HTML-content
+        html_paths = [p for p in paths if p.sink.sink_type == "HTML-content"]
+        assert len(html_paths) >= 1
+        assert all(p.is_sanitized for p in html_paths)
+
+    def test_unsanitized_flow_has_all_labels(self):
+        """Unsanitized taint path carries ALL_SINK_TYPES labels."""
+        code = '''
+def handler():
+    user_input = request.args.get('q')
+    eval(user_input)
+'''
+        paths = self.analyzer.analyze(code)
+        assert len(paths) >= 1
+        # The CODE-execution path should not be sanitized
+        code_paths = [p for p in paths if p.sink.sink_type == "CODE-execution"]
+        assert len(code_paths) >= 1
+        for p in code_paths:
+            assert not p.is_sanitized
+            # Should still have the CODE-execution label active
+            assert "CODE-execution" in p.taint_labels
+
+    def test_sanitizer_specific_to_sink_type(self):
+        """Sanitizer for one type does not remove labels for a different type."""
+        code = '''
+def handler():
+    user_input = request.args.get('q')
+    safe = html.escape(user_input)
+    cursor.execute(f"SELECT * FROM t WHERE x = {safe}")
+'''
+        paths = self.analyzer.analyze(code)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        # SQL-value label should still be active even though html.escape was applied
+        assert len(sql_paths) >= 1
+        for p in sql_paths:
+            assert not p.is_sanitized
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Issue #74: Interprocedural (cross-function) taint tracking
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestInterproceduralTaintTracking:
+    """Cross-function taint propagation within a single file."""
+
+    def setup_method(self):
+        self.analyzer = TaintAnalyzer()
+
+    def test_taint_through_function_call_argument(self):
+        """Taint flows from caller arg to callee param."""
+        code = '''
+def process_query(q):
+    cursor.execute(f"SELECT * FROM t WHERE x = {q}")
+
+def handler():
+    user_input = request.args.get('q')
+    process_query(user_input)
+'''
+        paths = self.analyzer.analyze(code)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        assert len(sql_paths) >= 1
+
+    def test_taint_through_return_value(self):
+        """Taint flows back from callee return to caller."""
+        code = '''
+def get_user_input():
+    return request.args.get('q')
+
+def handler():
+    data = get_user_input()
+    cursor.execute(f"SELECT * FROM t WHERE x = {data}")
+'''
+        paths = self.analyzer.analyze(code)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        assert len(sql_paths) >= 1
+
+    def test_taint_through_chain_of_functions(self):
+        """Taint flows through a chain: A -> B -> sink."""
+        code = '''
+def get_input():
+    return request.args.get('q')
+
+def transform(val):
+    return val.upper()
+
+def handler():
+    raw = get_input()
+    processed = transform(raw)
+    eval(processed)
+'''
+        paths = self.analyzer.analyze(code)
+        code_paths = [p for p in paths if p.sink.sink_type == "CODE-execution"]
+        assert len(code_paths) >= 1
+
+    def test_no_interprocedural_taint_when_clean(self):
+        """No false positives when functions don't handle tainted data."""
+        code = '''
+def compute(a, b):
+    return a + b
+
+def handler():
+    result = compute(1, 2)
+    print(result)
+'''
+        paths = self.analyzer.analyze(code)
+        assert len(paths) == 0
+
+    def test_taint_argument_propagation_multiple_params(self):
+        """Only the tainted argument position propagates taint."""
+        code = '''
+def process(safe_val, dangerous_val):
+    cursor.execute(f"SELECT * FROM t WHERE x = {dangerous_val}")
+
+def handler():
+    clean = "safe"
+    dirty = request.args.get('q')
+    process(clean, dirty)
+'''
+        paths = self.analyzer.analyze(code)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        assert len(sql_paths) >= 1
+
+    def test_interprocedural_with_cmd_injection(self):
+        """Cross-function command injection detection."""
+        code = '''
+def run_command(cmd):
+    os.system(cmd)
+
+def handle_request():
+    user_cmd = request.form['cmd']
+    run_command(user_cmd)
+'''
+        paths = self.analyzer.analyze(code)
+        cmd_paths = [p for p in paths if p.sink.sink_type == "CMD-argument"]
+        assert len(cmd_paths) >= 1
+
+    def test_self_param_excluded_from_taint_propagation(self):
+        """'self' and 'cls' parameters are not tracked for taint."""
+        code = '''
+class Handler:
+    def process(self, query):
+        cursor.execute(f"SELECT * FROM t WHERE x = {query}")
+
+    def handle(self):
+        user_input = request.args.get('q')
+        self.process(user_input)
+'''
+        paths = self.analyzer.analyze(code)
+        # Should still detect the taint flow (self is excluded from param tracking)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        assert len(sql_paths) >= 1
+
+    def test_function_return_taint_labels_preserved(self):
+        """Return value taint labels are preserved through interprocedural flow."""
+        code = '''
+def get_user_input():
+    return request.args.get('q')
+
+def handler():
+    data = get_user_input()
+    eval(data)
+'''
+        paths = self.analyzer.analyze(code)
+        code_paths = [p for p in paths if p.sink.sink_type == "CODE-execution"]
+        assert len(code_paths) >= 1
+        for p in code_paths:
+            assert not p.is_sanitized
+
+
+class TestInterproceduralWithMultiLabel:
+    """Combined interprocedural + multi-label behavior."""
+
+    def setup_method(self):
+        self.analyzer = TaintAnalyzer()
+
+    def test_sanitized_return_preserves_non_sanitized_labels(self):
+        """A function that sanitizes for HTML but returns to SQL sink is still tainted."""
+        code = '''
+def sanitize_for_html(val):
+    return html.escape(val)
+
+def handler():
+    user_input = request.args.get('q')
+    safe_html = sanitize_for_html(user_input)
+    cursor.execute(f"SELECT * FROM t WHERE x = {safe_html}")
+'''
+        paths = self.analyzer.analyze(code)
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+        # SQL path should still be detected (html.escape does not sanitize SQL)
+        assert len(sql_paths) >= 1
+        for p in sql_paths:
+            assert not p.is_sanitized
+
+    def test_multiple_sinks_different_label_state(self):
+        """Same variable reaching different sinks with different sanitization states."""
+        code = '''
+def handler():
+    user_input = request.args.get('q')
+    safe_html = html.escape(user_input)
+    render_template_string(safe_html)
+    cursor.execute(f"SELECT * FROM t WHERE x = {user_input}")
+'''
+        paths = self.analyzer.analyze(code)
+        html_paths = [p for p in paths if p.sink.sink_type == "HTML-content"]
+        sql_paths = [p for p in paths if p.sink.sink_type == "SQL-value"]
+
+        # HTML path is sanitized by html.escape
+        assert len(html_paths) >= 1
+        assert all(p.is_sanitized for p in html_paths)
+
+        # SQL path is NOT sanitized (different sink type)
+        assert len(sql_paths) >= 1
+        assert all(not p.is_sanitized for p in sql_paths)
+
+
+class TestBackwardCompatibility:
+    """Ensure the multi-label changes do not break existing API contracts."""
+
+    def test_legacy_is_sanitized_true(self):
+        """Legacy construction with is_sanitized=True."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source,
+            sink=sink,
+            sanitizers=["html.escape"],
+            is_sanitized=True,
+            confidence=0.27,
+        )
+        assert path.is_sanitized is True
+        assert path.confidence < 0.5
+
+    def test_legacy_is_sanitized_false(self):
+        """Legacy construction with is_sanitized=False."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(
+            source=source,
+            sink=sink,
+            is_sanitized=False,
+            confidence=0.9,
+        )
+        assert path.is_sanitized is False
+
+    def test_legacy_default_is_not_sanitized(self):
+        """Default construction (no is_sanitized) is not sanitized."""
+        source = TaintSource(name="request.args", node_type="attribute", line=1)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=5)
+        path = TaintPath(source=source, sink=sink, confidence=0.9)
+        assert path.is_sanitized is False
+
+    def test_sink_type_property_still_works(self):
+        """The sink_type property on TaintPath still works."""
+        source = TaintSource(name="input", node_type="call", line=1)
+        sink = TaintSink(name="eval", sink_type="CODE-execution", line=2)
+        path = TaintPath(source=source, sink=sink, confidence=0.9)
+        assert path.sink_type == "CODE-execution"
+
+    def test_to_json_backward_compatible(self):
+        """to_json still has all legacy keys."""
+        source = TaintSource(name="request.args", node_type="attribute", line=5)
+        sink = TaintSink(name="cursor.execute", sink_type="SQL-value", line=10)
+        path = TaintPath(source=source, sink=sink, confidence=0.9)
+        j = path.to_json()
+        assert "source" in j
+        assert "sink" in j
+        assert "transformations" in j
+        assert "sanitizers" in j
+        assert "is_sanitized" in j
+        assert "confidence" in j
+        # New field also present
+        assert "taint_labels" in j
+
+    def test_existing_sql_injection_still_detected(self):
+        """Regression: basic SQL injection detection unchanged."""
+        analyzer = TaintAnalyzer()
+        code = '''
+def get_user(user_id):
+    uid = request.args.get('id')
+    cursor.execute(f"SELECT * FROM users WHERE id = {uid}")
+'''
+        paths = analyzer.analyze(code)
+        assert len(paths) >= 1
+        assert any(p.sink.sink_type == "SQL-value" for p in paths)
+
+    def test_existing_cmd_injection_still_detected(self):
+        """Regression: basic command injection detection unchanged."""
+        analyzer = TaintAnalyzer()
+        code = '''
+def run_cmd():
+    cmd = request.form['command']
+    os.system(cmd)
+'''
+        paths = analyzer.analyze(code)
+        assert len(paths) >= 1
+        assert any(p.sink.sink_type == "CMD-argument" for p in paths)
+
+    def test_existing_eval_injection_still_detected(self):
+        """Regression: eval injection detection unchanged."""
+        analyzer = TaintAnalyzer()
+        code = '''
+def greet():
+    name = input("Name: ")
+    eval(name)
+'''
+        paths = analyzer.analyze(code)
+        assert len(paths) >= 1
+        assert any(p.sink.sink_type == "CODE-execution" for p in paths)
+
+    def test_existing_clean_code_still_clean(self):
+        """Regression: clean code produces no paths."""
+        analyzer = TaintAnalyzer()
+        code = '''
+def calculate(a, b):
+    return a + b
+'''
+        paths = analyzer.analyze(code)
+        assert len(paths) == 0
+
+    def test_existing_js_analysis_unchanged(self):
+        """Regression: JS taint analysis still works."""
+        analyzer = TaintAnalyzer()
+        code = "const id = req.query.id;\ndb.query(`SELECT * FROM users WHERE id = ${id}`);"
+        paths = analyzer.analyze(code, language="javascript")
+        assert len(paths) >= 1
+        assert any(p.sink.sink_type == "SQL-value" for p in paths)


### PR DESCRIPTION
## Summary
- **Issue #74**: Implement Phase 1 interprocedural (cross-function) taint tracking within a single file. Builds a call graph from AST, propagates taint from caller arguments to callee parameters, tracks return values as taint propagators, and resolves method calls (`self.foo` -> `foo`).
- **Issue #75**: Replace binary `is_sanitized: bool` with per-sink-type `taint_labels: set[str]`. Sanitizers now remove only their specific label (e.g., `html.escape` removes `HTML-content` but not `SQL-value`). A variable is clean only when `taint_labels` is empty. Full backward compatibility maintained via computed `is_sanitized` property.
- Extended `_is_tainted` to propagate taint through all function call arguments (not just `.format()`), enabling detection of flows through `html.escape(tainted)`, `str(tainted)`, etc.

## Test plan
- [x] All 125 existing taint tests pass with zero regressions
- [x] 32 new tests covering interprocedural tracking, multi-label taint, backward compatibility
- [x] All 294 security frame tests pass
- [ ] Verify CI passes on all workflows
- [ ] Manual review of edge cases: recursive functions, deeply nested calls

Closes #74
Closes #75