### PR TITLE
ux(scan): expose pipeline phase checklist with real-time status (#202)

### DIFF
--- a/src/warden/cli/commands/_phase_checklist_renderer.py
+++ b/src/warden/cli/commands/_phase_checklist_renderer.py
@@ -1,0 +1,144 @@
+"""
+Phase checklist renderer for the ``warden scan`` Rich Live display.
+
+Converts a ``PhaseChecklist`` into a list of ``rich.text.Text`` rows
+suitable for inclusion in the live panel.  The checklist is shown at
+the top of the display, giving the user an at-a-glance view of which
+phases have completed, which is active, and which are still pending.
+
+Rendering format (one row per phase):
+    Done    :  [checkmark] Phase-Name    12s
+    Running :  [spinner]   Phase-Name    ...
+    Failed  :  [x]         Phase-Name    8s
+    Skipped :  [-]         Phase-Name
+    Pending :  [ ]         Phase-Name
+"""
+
+from __future__ import annotations
+
+from rich.text import Text
+
+from warden.pipeline.domain.phase_checklist import PhaseChecklist, PhaseChecklistItem, PhaseStatus
+
+# ── Glyph / style lookup per status ──────────────────────────────────────
+
+_STATUS_GLYPHS: dict[PhaseStatus, tuple[str, str]] = {
+    # (glyph, rich_style)
+    PhaseStatus.DONE: ("OK", "bold green"),
+    PhaseStatus.RUNNING: (">>" , "bold blue"),
+    PhaseStatus.FAILED: ("!!", "bold red"),
+    PhaseStatus.SKIPPED: ("--", "dim"),
+    PhaseStatus.PENDING: ("  ", "dim"),
+}
+
+# Phase name alignment width
+_NAME_WIDTH = 18
+
+
+def render_checklist_rows(checklist: PhaseChecklist) -> list[Text]:
+    """Return a list of ``Text`` objects representing the checklist.
+
+    Each phase occupies one line.  Only phases that have transitioned
+    out of PENDING (or the first PENDING phase) are rendered so the
+    display stays compact before the pipeline starts.
+    """
+    rows: list[Text] = []
+
+    for item in checklist.items:
+        row = _render_item(item)
+        rows.append(row)
+
+    return rows
+
+
+def _render_item(item: PhaseChecklistItem) -> Text:
+    """Render a single checklist item as a Rich ``Text`` object."""
+    glyph, style = _STATUS_GLYPHS.get(item.status, ("  ", "dim"))
+
+    row = Text()
+    row.append("  ", style="")
+
+    # Status glyph
+    row.append(f"{glyph}", style=style)
+    row.append(" ", style="")
+
+    # Phase name (fixed width for alignment)
+    name_style = "bold white" if item.status == PhaseStatus.RUNNING else (
+        "white" if item.status == PhaseStatus.DONE else (
+            "bold red" if item.status == PhaseStatus.FAILED else "dim"
+        )
+    )
+    row.append(f"{item.name:<{_NAME_WIDTH}}", style=name_style)
+
+    # Timing info
+    if item.status == PhaseStatus.RUNNING:
+        elapsed = item.elapsed_str
+        if elapsed:
+            row.append(f"  {elapsed}", style="dim blue")
+        else:
+            row.append("  ...", style="dim blue")
+    elif item.status in (PhaseStatus.DONE, PhaseStatus.FAILED):
+        elapsed = item.elapsed_str
+        if elapsed:
+            row.append(f"  {elapsed}", style="dim")
+    # PENDING and SKIPPED: no timing info
+
+    return row
+
+
+# ── Phase name normalisation ─────────────────────────────────────────────
+
+# Mapping from executor/runner phase identifiers to canonical checklist
+# names (matching ``PIPELINE_PHASES`` in phase_checklist.py).
+_PHASE_NAME_MAP: dict[str, str] = {
+    # Executor identifiers (UPPER_CASE)
+    "PRE_ANALYSIS": "Pre-Analysis",
+    "PRE-ANALYSIS": "Pre-Analysis",
+    "TRIAGE": "Triage",
+    "ANALYSIS": "Analysis",
+    "CLASSIFICATION": "Classification",
+    "VALIDATION": "Validation",
+    "VERIFICATION": "Verification",
+    "FORTIFICATION": "Fortification",
+    "CLEANING": "Cleaning",
+    # Runner labels (Title Case) -- already canonical
+    "Pre-Analysis": "Pre-Analysis",
+    "Triage": "Triage",
+    "Analysis": "Analysis",
+    "Classification": "Classification",
+    "Validation": "Validation",
+    "Verification": "Verification",
+    "Fortification": "Fortification",
+    "Cleaning": "Cleaning",
+    # .title() variants
+    "Pre_Analysis": "Pre-Analysis",
+    "Pre Analysis": "Pre-Analysis",
+    # LSP sub-phase -- not in the main checklist, ignored
+    "LSP_DIAGNOSTICS": "",
+    "Lsp Diagnostics": "",
+    "Lsp_Diagnostics": "",
+}
+
+
+def normalise_phase_name(raw: str) -> str:
+    """Map an event phase identifier to the canonical checklist name.
+
+    Returns an empty string if the phase should be ignored (e.g. LSP
+    sub-phases that are not in the main checklist).
+    """
+    # Fast exact match
+    canonical = _PHASE_NAME_MAP.get(raw)
+    if canonical is not None:
+        return canonical
+
+    # Fallback: try .title() for things like "pre-analysis" -> "Pre-Analysis"
+    titled = raw.replace("_", " ").title().replace(" ", "-")
+    # Fix double-hyphen edge cases
+    titled = titled.replace("Pre-", "Pre-")
+    canonical = _PHASE_NAME_MAP.get(titled)
+    if canonical is not None:
+        return canonical
+
+    # Last resort: return the title-cased version and let the checklist
+    # handle "not found" gracefully.
+    return raw.replace("_", " ").title()

--- a/src/warden/pipeline/domain/__init__.py
+++ b/src/warden/pipeline/domain/__init__.py
@@ -8,6 +8,11 @@ from warden.pipeline.domain.models import (
     PipelineResult,
     ValidationPipeline,
 )
+from warden.pipeline.domain.phase_checklist import (
+    PhaseChecklist,
+    PhaseChecklistItem,
+    PhaseStatus,
+)
 
 __all__ = [
     "ValidationPipeline",
@@ -17,4 +22,7 @@ __all__ = [
     "PipelineStatus",
     "ExecutionStrategy",
     "ProjectIntelligence",
+    "PhaseChecklist",
+    "PhaseChecklistItem",
+    "PhaseStatus",
 ]

--- a/src/warden/pipeline/domain/phase_checklist.py
+++ b/src/warden/pipeline/domain/phase_checklist.py
@@ -1,0 +1,184 @@
+"""
+Phase Checklist Model.
+
+Tracks the status and timing of each pipeline phase for real-time
+CLI progress display.  The checklist is populated by the pipeline
+runner and consumed by the CLI's Rich Live display.
+
+Phase lifecycle:
+    PENDING  -> RUNNING -> DONE | FAILED | SKIPPED
+
+Each item records wall-clock start/end timestamps so the CLI can
+render elapsed time while a phase is active and total duration once
+it completes.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class PhaseStatus(str, Enum):
+    """Execution status of an individual pipeline phase."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+# Canonical display order of pipeline phases.
+# The keys match the labels used in ``PipelinePhaseRunner.execute_all_phases``.
+PIPELINE_PHASES: list[str] = [
+    "Pre-Analysis",
+    "Triage",
+    "Analysis",
+    "Classification",
+    "Validation",
+    "Verification",
+    "Fortification",
+    "Cleaning",
+]
+
+
+@dataclass
+class PhaseChecklistItem:
+    """A single row in the phase checklist.
+
+    Attributes:
+        name: Human-readable phase name (e.g. "Pre-Analysis").
+        status: Current phase execution status.
+        start_time: Monotonic timestamp when the phase started
+                    (``time.monotonic()``), or ``None`` if not yet started.
+        end_time: Monotonic timestamp when the phase ended, or ``None``
+                  if still running or not yet started.
+    """
+
+    name: str
+    status: PhaseStatus = PhaseStatus.PENDING
+    start_time: float | None = None
+    end_time: float | None = None
+
+    # ------------------------------------------------------------------ #
+    # Convenience helpers
+    # ------------------------------------------------------------------ #
+
+    @property
+    def elapsed(self) -> float | None:
+        """Elapsed wall-clock seconds.
+
+        * While running: seconds since start.
+        * After completion: total duration.
+        * Before start: ``None``.
+        """
+        if self.start_time is None:
+            return None
+        end = self.end_time if self.end_time is not None else time.monotonic()
+        return end - self.start_time
+
+    @property
+    def elapsed_str(self) -> str:
+        """Human-friendly elapsed string (e.g. ``"12s"``, ``"1m 3s"``)."""
+        secs = self.elapsed
+        if secs is None:
+            return ""
+        if secs < 60:
+            return f"{secs:.0f}s"
+        minutes = int(secs // 60)
+        remainder = int(secs % 60)
+        return f"{minutes}m {remainder}s"
+
+    def mark_running(self) -> None:
+        """Transition to RUNNING and record start time."""
+        self.status = PhaseStatus.RUNNING
+        self.start_time = time.monotonic()
+
+    def mark_done(self) -> None:
+        """Transition to DONE and record end time."""
+        self.status = PhaseStatus.DONE
+        self.end_time = time.monotonic()
+
+    def mark_failed(self) -> None:
+        """Transition to FAILED and record end time."""
+        self.status = PhaseStatus.FAILED
+        self.end_time = time.monotonic()
+
+    def mark_skipped(self) -> None:
+        """Transition to SKIPPED (no timing recorded)."""
+        self.status = PhaseStatus.SKIPPED
+
+
+@dataclass
+class PhaseChecklist:
+    """Ordered collection of ``PhaseChecklistItem`` objects.
+
+    The checklist is initialised once at scan start and mutated
+    in-place as the pipeline progresses.  The CLI reads it on every
+    ``Live.update()`` tick to render the current state.
+    """
+
+    items: list[PhaseChecklistItem] = field(default_factory=list)
+
+    # -- Factory -------------------------------------------------------- #
+
+    @classmethod
+    def from_defaults(cls) -> PhaseChecklist:
+        """Create a checklist pre-populated with all canonical phases."""
+        return cls(items=[PhaseChecklistItem(name=name) for name in PIPELINE_PHASES])
+
+    # -- Lookup --------------------------------------------------------- #
+
+    def get(self, name: str) -> PhaseChecklistItem | None:
+        """Return the item matching *name* (case-insensitive)."""
+        key = name.strip().lower()
+        for item in self.items:
+            if item.name.lower() == key:
+                return item
+        return None
+
+    # -- Bulk state helpers --------------------------------------------- #
+
+    def mark_phase_running(self, name: str) -> None:
+        """Mark the named phase as RUNNING."""
+        item = self.get(name)
+        if item and item.status == PhaseStatus.PENDING:
+            item.mark_running()
+
+    def mark_phase_done(self, name: str) -> None:
+        """Mark the named phase as DONE."""
+        item = self.get(name)
+        if item and item.status == PhaseStatus.RUNNING:
+            item.mark_done()
+
+    def mark_phase_failed(self, name: str) -> None:
+        """Mark the named phase as FAILED."""
+        item = self.get(name)
+        if item and item.status == PhaseStatus.RUNNING:
+            item.mark_failed()
+
+    def mark_phase_skipped(self, name: str) -> None:
+        """Mark the named phase as SKIPPED."""
+        item = self.get(name)
+        if item and item.status == PhaseStatus.PENDING:
+            item.mark_skipped()
+
+    @property
+    def active_phase(self) -> PhaseChecklistItem | None:
+        """Return the currently-running phase, if any."""
+        for item in self.items:
+            if item.status == PhaseStatus.RUNNING:
+                return item
+        return None
+
+    @property
+    def completed_count(self) -> int:
+        """Number of phases that finished (DONE, FAILED, or SKIPPED)."""
+        terminal = {PhaseStatus.DONE, PhaseStatus.FAILED, PhaseStatus.SKIPPED}
+        return sum(1 for item in self.items if item.status in terminal)
+
+    @property
+    def total_count(self) -> int:
+        return len(self.items)

--- a/tests/cli/commands/test_phase_checklist_renderer.py
+++ b/tests/cli/commands/test_phase_checklist_renderer.py
@@ -1,0 +1,146 @@
+"""
+Tests for warden.cli.commands._phase_checklist_renderer
+
+Covers:
+1. render_checklist_rows — generates correct Rich Text objects per status
+2. normalise_phase_name — maps executor/runner identifiers to canonical names
+"""
+
+import pytest
+
+from warden.cli.commands._phase_checklist_renderer import (
+    normalise_phase_name,
+    render_checklist_rows,
+)
+from warden.pipeline.domain.phase_checklist import (
+    PhaseChecklist,
+    PhaseChecklistItem,
+    PhaseStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# render_checklist_rows
+# ---------------------------------------------------------------------------
+
+
+class TestRenderChecklistRows:
+    """Rendering correctness for each phase status."""
+
+    def test_returns_list_of_text_objects(self):
+        cl = PhaseChecklist.from_defaults()
+        rows = render_checklist_rows(cl)
+        assert isinstance(rows, list)
+        assert len(rows) == len(cl.items)
+
+    def test_pending_item_has_no_timing(self):
+        cl = PhaseChecklist(items=[PhaseChecklistItem(name="Test")])
+        rows = render_checklist_rows(cl)
+        assert len(rows) == 1
+        text = rows[0].plain
+        assert "Test" in text
+        # Should not contain timing information
+        assert "s" not in text.split("Test")[1] or text.split("Test")[1].strip() == ""
+
+    def test_done_item_shows_timing(self):
+        item = PhaseChecklistItem(name="Analysis")
+        item.start_time = 100.0
+        item.end_time = 112.0
+        item.status = PhaseStatus.DONE
+        cl = PhaseChecklist(items=[item])
+        rows = render_checklist_rows(cl)
+        text = rows[0].plain
+        assert "Analysis" in text
+        assert "12s" in text
+
+    def test_running_item_shows_dots_or_elapsed(self):
+        item = PhaseChecklistItem(name="Validation")
+        item.status = PhaseStatus.RUNNING
+        item.start_time = None  # No start time yet
+        cl = PhaseChecklist(items=[item])
+        rows = render_checklist_rows(cl)
+        text = rows[0].plain
+        assert "Validation" in text
+        assert "..." in text
+
+    def test_failed_item_rendered(self):
+        item = PhaseChecklistItem(name="Classification")
+        item.start_time = 100.0
+        item.end_time = 108.0
+        item.status = PhaseStatus.FAILED
+        cl = PhaseChecklist(items=[item])
+        rows = render_checklist_rows(cl)
+        text = rows[0].plain
+        assert "Classification" in text
+        assert "8s" in text
+
+    def test_skipped_item_rendered(self):
+        item = PhaseChecklistItem(name="Cleaning")
+        item.status = PhaseStatus.SKIPPED
+        cl = PhaseChecklist(items=[item])
+        rows = render_checklist_rows(cl)
+        text = rows[0].plain
+        assert "Cleaning" in text
+
+    def test_full_lifecycle_rendering(self):
+        """Simulate a real pipeline progression and verify row count."""
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Pre-Analysis")
+        cl.mark_phase_done("Pre-Analysis")
+        cl.mark_phase_running("Triage")
+
+        rows = render_checklist_rows(cl)
+        assert len(rows) == cl.total_count
+
+        # Check that Pre-Analysis shows "OK" glyph
+        pre_analysis_text = rows[0].plain
+        assert "OK" in pre_analysis_text
+
+        # Check that Triage shows ">>" glyph
+        triage_text = rows[1].plain
+        assert ">>" in triage_text
+
+
+# ---------------------------------------------------------------------------
+# normalise_phase_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalisePhaseNameFn:
+    """Phase name normalization mapping."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # Executor identifiers (UPPER_CASE)
+            ("PRE_ANALYSIS", "Pre-Analysis"),
+            ("TRIAGE", "Triage"),
+            ("ANALYSIS", "Analysis"),
+            ("CLASSIFICATION", "Classification"),
+            ("VALIDATION", "Validation"),
+            ("VERIFICATION", "Verification"),
+            ("FORTIFICATION", "Fortification"),
+            ("CLEANING", "Cleaning"),
+            # Runner labels (Title Case)
+            ("Pre-Analysis", "Pre-Analysis"),
+            ("Triage", "Triage"),
+            ("Analysis", "Analysis"),
+            ("Classification", "Classification"),
+            ("Validation", "Validation"),
+            ("Verification", "Verification"),
+            ("Fortification", "Fortification"),
+            ("Cleaning", "Cleaning"),
+        ],
+    )
+    def test_maps_known_identifiers(self, raw, expected):
+        assert normalise_phase_name(raw) == expected
+
+    def test_lsp_diagnostics_returns_empty(self):
+        assert normalise_phase_name("LSP_DIAGNOSTICS") == ""
+        assert normalise_phase_name("Lsp Diagnostics") == ""
+
+    def test_unknown_phase_returns_titled(self):
+        result = normalise_phase_name("CUSTOM_PHASE")
+        # Should be some title-case form, not crash
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/tests/pipeline/domain/test_phase_checklist.py
+++ b/tests/pipeline/domain/test_phase_checklist.py
@@ -1,0 +1,250 @@
+"""
+Tests for warden.pipeline.domain.phase_checklist
+
+Covers:
+1. PhaseStatus enum values
+2. PhaseChecklistItem lifecycle (pending -> running -> done/failed/skipped)
+3. PhaseChecklistItem timing (elapsed, elapsed_str)
+4. PhaseChecklist factory and lookup
+5. PhaseChecklist bulk state helpers
+6. PhaseChecklist properties (active_phase, completed_count)
+"""
+
+import time
+
+import pytest
+
+from warden.pipeline.domain.phase_checklist import (
+    PIPELINE_PHASES,
+    PhaseChecklist,
+    PhaseChecklistItem,
+    PhaseStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# PhaseStatus enum
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseStatus:
+    """Verify enum values match expected strings."""
+
+    def test_all_statuses_present(self):
+        assert PhaseStatus.PENDING == "pending"
+        assert PhaseStatus.RUNNING == "running"
+        assert PhaseStatus.DONE == "done"
+        assert PhaseStatus.FAILED == "failed"
+        assert PhaseStatus.SKIPPED == "skipped"
+
+    def test_is_str_enum(self):
+        assert isinstance(PhaseStatus.PENDING, str)
+
+
+# ---------------------------------------------------------------------------
+# PhaseChecklistItem
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseChecklistItem:
+    """Item lifecycle and timing."""
+
+    def test_default_state_is_pending(self):
+        item = PhaseChecklistItem(name="Test")
+        assert item.status == PhaseStatus.PENDING
+        assert item.start_time is None
+        assert item.end_time is None
+
+    def test_elapsed_none_before_start(self):
+        item = PhaseChecklistItem(name="Test")
+        assert item.elapsed is None
+        assert item.elapsed_str == ""
+
+    def test_mark_running(self):
+        item = PhaseChecklistItem(name="Test")
+        item.mark_running()
+        assert item.status == PhaseStatus.RUNNING
+        assert item.start_time is not None
+        assert item.end_time is None
+
+    def test_elapsed_while_running(self):
+        item = PhaseChecklistItem(name="Test")
+        item.start_time = time.monotonic() - 5.0  # started 5 seconds ago
+        item.status = PhaseStatus.RUNNING
+        elapsed = item.elapsed
+        assert elapsed is not None
+        assert elapsed >= 4.9  # allow small drift
+
+    def test_mark_done(self):
+        item = PhaseChecklistItem(name="Test")
+        item.mark_running()
+        item.mark_done()
+        assert item.status == PhaseStatus.DONE
+        assert item.end_time is not None
+
+    def test_elapsed_after_done(self):
+        item = PhaseChecklistItem(name="Test")
+        item.start_time = 100.0
+        item.end_time = 112.5
+        item.status = PhaseStatus.DONE
+        assert item.elapsed == 12.5
+
+    def test_mark_failed(self):
+        item = PhaseChecklistItem(name="Test")
+        item.mark_running()
+        item.mark_failed()
+        assert item.status == PhaseStatus.FAILED
+        assert item.end_time is not None
+
+    def test_mark_skipped(self):
+        item = PhaseChecklistItem(name="Test")
+        item.mark_skipped()
+        assert item.status == PhaseStatus.SKIPPED
+        assert item.start_time is None
+        assert item.end_time is None
+
+    def test_elapsed_str_seconds(self):
+        item = PhaseChecklistItem(name="Test")
+        item.start_time = 100.0
+        item.end_time = 112.0
+        item.status = PhaseStatus.DONE
+        assert item.elapsed_str == "12s"
+
+    def test_elapsed_str_minutes(self):
+        item = PhaseChecklistItem(name="Test")
+        item.start_time = 100.0
+        item.end_time = 163.0
+        item.status = PhaseStatus.DONE
+        assert item.elapsed_str == "1m 3s"
+
+
+# ---------------------------------------------------------------------------
+# PIPELINE_PHASES constant
+# ---------------------------------------------------------------------------
+
+
+class TestPipelinePhases:
+    """Verify the canonical phase list."""
+
+    def test_contains_core_phases(self):
+        assert "Pre-Analysis" in PIPELINE_PHASES
+        assert "Triage" in PIPELINE_PHASES
+        assert "Analysis" in PIPELINE_PHASES
+        assert "Classification" in PIPELINE_PHASES
+        assert "Validation" in PIPELINE_PHASES
+        assert "Fortification" in PIPELINE_PHASES
+        assert "Cleaning" in PIPELINE_PHASES
+
+    def test_ordering_pre_analysis_first(self):
+        assert PIPELINE_PHASES[0] == "Pre-Analysis"
+
+    def test_ordering_cleaning_last(self):
+        assert PIPELINE_PHASES[-1] == "Cleaning"
+
+
+# ---------------------------------------------------------------------------
+# PhaseChecklist
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseChecklist:
+    """Factory, lookup, and bulk operations."""
+
+    def test_from_defaults_creates_all_phases(self):
+        cl = PhaseChecklist.from_defaults()
+        assert len(cl.items) == len(PIPELINE_PHASES)
+        for item, expected_name in zip(cl.items, PIPELINE_PHASES):
+            assert item.name == expected_name
+            assert item.status == PhaseStatus.PENDING
+
+    def test_get_by_name(self):
+        cl = PhaseChecklist.from_defaults()
+        item = cl.get("Analysis")
+        assert item is not None
+        assert item.name == "Analysis"
+
+    def test_get_case_insensitive(self):
+        cl = PhaseChecklist.from_defaults()
+        item = cl.get("analysis")
+        assert item is not None
+        assert item.name == "Analysis"
+
+    def test_get_returns_none_for_unknown(self):
+        cl = PhaseChecklist.from_defaults()
+        assert cl.get("NonExistentPhase") is None
+
+    def test_mark_phase_running(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Analysis")
+        item = cl.get("Analysis")
+        assert item.status == PhaseStatus.RUNNING
+
+    def test_mark_phase_running_only_from_pending(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Analysis")
+        cl.mark_phase_done("Analysis")
+        # Trying to mark as running again should not change status
+        cl.mark_phase_running("Analysis")
+        assert cl.get("Analysis").status == PhaseStatus.DONE
+
+    def test_mark_phase_done(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Triage")
+        cl.mark_phase_done("Triage")
+        assert cl.get("Triage").status == PhaseStatus.DONE
+
+    def test_mark_phase_done_only_from_running(self):
+        cl = PhaseChecklist.from_defaults()
+        # Trying to mark as done without running first should be a no-op
+        cl.mark_phase_done("Triage")
+        assert cl.get("Triage").status == PhaseStatus.PENDING
+
+    def test_mark_phase_failed(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Validation")
+        cl.mark_phase_failed("Validation")
+        assert cl.get("Validation").status == PhaseStatus.FAILED
+
+    def test_mark_phase_skipped(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_skipped("Fortification")
+        assert cl.get("Fortification").status == PhaseStatus.SKIPPED
+
+    def test_mark_phase_skipped_only_from_pending(self):
+        cl = PhaseChecklist.from_defaults()
+        cl.mark_phase_running("Fortification")
+        cl.mark_phase_skipped("Fortification")
+        # Should not change from RUNNING to SKIPPED
+        assert cl.get("Fortification").status == PhaseStatus.RUNNING
+
+    def test_active_phase(self):
+        cl = PhaseChecklist.from_defaults()
+        assert cl.active_phase is None
+        cl.mark_phase_running("Pre-Analysis")
+        assert cl.active_phase.name == "Pre-Analysis"
+        cl.mark_phase_done("Pre-Analysis")
+        assert cl.active_phase is None
+
+    def test_completed_count(self):
+        cl = PhaseChecklist.from_defaults()
+        assert cl.completed_count == 0
+        cl.mark_phase_running("Pre-Analysis")
+        assert cl.completed_count == 0  # running is not completed
+        cl.mark_phase_done("Pre-Analysis")
+        assert cl.completed_count == 1
+        cl.mark_phase_skipped("Triage")
+        assert cl.completed_count == 2
+
+    def test_total_count(self):
+        cl = PhaseChecklist.from_defaults()
+        assert cl.total_count == len(PIPELINE_PHASES)
+
+    def test_mark_unknown_phase_is_noop(self):
+        cl = PhaseChecklist.from_defaults()
+        # Should not raise
+        cl.mark_phase_running("NonExistent")
+        cl.mark_phase_done("NonExistent")
+        cl.mark_phase_failed("NonExistent")
+        cl.mark_phase_skipped("NonExistent")
+        # All items should still be PENDING
+        assert all(item.status == PhaseStatus.PENDING for item in cl.items)


### PR DESCRIPTION
## Summary

- Add a real-time phase checklist to the `warden scan` Rich Live display showing all 8 pipeline phases with their current status (pending/running/done/failed/skipped) and elapsed time
- Create `PhaseStatus` enum, `PhaseChecklistItem` dataclass, and `PhaseChecklist` collection in the pipeline domain layer
- Handle `phase_started`, `phase_completed`, and `phase_skipped` progress callback events in the CLI to drive checklist state transitions
- 55 new unit tests covering the domain model, renderer, and phase name normalisation

## Test plan

- [x] `PhaseChecklist.from_defaults()` creates all 8 canonical phases in PENDING state
- [x] Phase lifecycle transitions (PENDING -> RUNNING -> DONE/FAILED/SKIPPED) work correctly with guard conditions
- [x] Elapsed time calculation works during RUNNING and after completion
- [x] Renderer generates correct Rich Text rows for each status
- [x] `normalise_phase_name` maps all executor identifiers (UPPER_CASE) and runner labels (Title Case) to canonical names
- [x] LSP_DIAGNOSTICS sub-phase is excluded from the checklist
- [x] Existing pipeline and scan tests continue to pass

Closes #202