### PR TITLE
feat(llm): add ProviderSpeedBenchmarkService for dynamic max_tokens

### DIFF
--- a/src/warden/llm/provider_speed_benchmark.py
+++ b/src/warden/llm/provider_speed_benchmark.py
@@ -1,0 +1,269 @@
+"""
+Provider Speed Benchmark Service
+
+Measures local LLM provider throughput at runtime and calculates a safe
+max_tokens budget that fits within the phase timeout.
+
+Cloud providers (Groq, OpenAI, Anthropic, etc.) are bypassed — they are
+fast enough that the static config default is always fine.
+
+Singleton pattern mirrors GlobalRateLimiter (global_rate_limiter.py).
+"""
+
+import asyncio
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from warden.llm.types import LlmRequest
+from warden.shared.infrastructure.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Module-level threading lock — safe across event loops (same as GlobalRateLimiter)
+_init_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class ProviderSpeedResult:
+    """Immutable value object for a single benchmark measurement."""
+
+    cache_key: str
+    tok_per_sec: float
+    safe_max_tokens: int
+    measured_at: float  # time.monotonic()
+
+
+class ProviderSpeedBenchmarkService:
+    """
+    Singleton service that benchmarks local LLM throughput and computes a
+    safe max_tokens budget for a given phase timeout.
+
+    Cloud providers are bypassed immediately — no measurement overhead.
+
+    Thread-safe singleton initialization (threading.Lock double-check).
+    Async-safe benchmark execution (asyncio.Lock per service instance).
+
+    Usage:
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        tokens = await svc.get_safe_max_tokens(client, timeout_s=120, default=800)
+    """
+
+    # Tuning constants
+    SAFETY_MARGIN: float = 0.75
+    BENCHMARK_TIMEOUT_S: float = 30.0
+    BENCHMARK_TOKEN_COUNT: int = 20
+    CACHE_TTL_S: float = 300.0  # 5 minutes
+    MAX_TOKENS_CEILING: int = 4000
+    MAX_TOKENS_FLOOR: int = 100
+
+    # Providers where throughput measurement makes sense
+    _LOCAL_PROVIDER_VALUES: frozenset[str] = frozenset({"ollama", "claude_code", "codex"})
+
+    _instance: "ProviderSpeedBenchmarkService | None" = None
+
+    def __init__(self) -> None:
+        if ProviderSpeedBenchmarkService._instance is not None:
+            raise RuntimeError("Use ProviderSpeedBenchmarkService.get_instance() instead")
+        self._cache: dict[str, tuple[ProviderSpeedResult, float]] = {}
+        # Lazily created — ensures the correct running event loop is used
+        self._benchmark_lock: asyncio.Lock | None = None
+
+    # ------------------------------------------------------------------
+    # Singleton lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_instance(cls) -> "ProviderSpeedBenchmarkService":
+        """Get or create the singleton instance (thread-safe double-check)."""
+        if cls._instance is not None:
+            return cls._instance
+        with _init_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton (test isolation only)."""
+        with _init_lock:
+            cls._instance = None
+
+    # ------------------------------------------------------------------
+    # Async lock (lazy init)
+    # ------------------------------------------------------------------
+
+    async def _get_lock(self) -> asyncio.Lock:
+        """Return the asyncio.Lock, creating it lazily on first call."""
+        if self._benchmark_lock is None:
+            self._benchmark_lock = asyncio.Lock()
+        return self._benchmark_lock
+
+    # ------------------------------------------------------------------
+    # Pure helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_local_provider(client: Any) -> bool:
+        """
+        Return True for Ollama, Claude Code, Codex, or localhost endpoints.
+
+        Checks the provider enum/string value first, then falls back to
+        inspecting the endpoint URL for loopback addresses.
+        """
+        provider_raw: Any = getattr(client, "provider", "")
+        # getattr handles both enum (.value) and plain string providers
+        provider_str = str(getattr(provider_raw, "value", provider_raw)).lower()
+
+        if provider_str in ProviderSpeedBenchmarkService._LOCAL_PROVIDER_VALUES:
+            return True
+
+        # Detect generic local HTTP endpoint (LMStudio, LocalAI, etc.)
+        endpoint = getattr(client, "endpoint", getattr(client, "_endpoint", ""))
+        str_endpoint = str(endpoint).lower()
+        return any(loopback in str_endpoint for loopback in ("localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"))
+
+    @staticmethod
+    def _get_cache_key(client: Any) -> str:
+        """Stable key: 'provider_value@endpoint'."""
+        provider_raw: Any = getattr(client, "provider", "unknown")
+        provider_str = str(getattr(provider_raw, "value", provider_raw)).lower()
+        endpoint = getattr(client, "endpoint", getattr(client, "_endpoint", ""))
+        return f"{provider_str}@{endpoint}"
+
+    @staticmethod
+    def _calculate(tok_per_sec: float, timeout_s: float) -> int:
+        """
+        Compute safe max_tokens given measured throughput and phase timeout.
+
+        Formula: floor(tok_per_sec × timeout_s × SAFETY_MARGIN)
+        Clamped to [MAX_TOKENS_FLOOR, MAX_TOKENS_CEILING].
+        """
+        cls = ProviderSpeedBenchmarkService
+        if tok_per_sec <= 0:
+            return cls.MAX_TOKENS_FLOOR
+        raw = int(tok_per_sec * timeout_s * cls.SAFETY_MARGIN)
+        return min(cls.MAX_TOKENS_CEILING, max(cls.MAX_TOKENS_FLOOR, raw))
+
+    # ------------------------------------------------------------------
+    # I/O core
+    # ------------------------------------------------------------------
+
+    async def _run_benchmark_async(self, client: Any) -> ProviderSpeedResult:
+        """
+        Send a minimal request to measure tokens/second.
+
+        Uses client.send_async() directly (no complete_async wrapper) to
+        avoid ExternalServiceError masking actual benchmark errors.
+
+        Token count: completion_tokens from response if available, else
+        len(content) // 4 heuristic.
+        """
+        cache_key = self._get_cache_key(client)
+        request = LlmRequest(
+            system_prompt="Respond with a short sentence.",
+            user_message="Say 'hello world' in 3 different ways.",
+            max_tokens=self.BENCHMARK_TOKEN_COUNT,
+            timeout_seconds=self.BENCHMARK_TIMEOUT_S,
+            use_fast_tier=True,
+        )
+
+        t0 = time.monotonic()
+        response = await client.send_async(request)
+        elapsed = time.monotonic() - t0
+
+        if response.completion_tokens and response.completion_tokens > 0:
+            tokens_produced = response.completion_tokens
+        else:
+            tokens_produced = max(1, len(response.content) // 4)
+
+        tok_per_sec = tokens_produced / max(elapsed, 0.001)
+        # safe_max_tokens stored with a fixed reference timeout; recalculated per call
+        safe_max = self._calculate(tok_per_sec, 120.0)
+
+        result = ProviderSpeedResult(
+            cache_key=cache_key,
+            tok_per_sec=tok_per_sec,
+            safe_max_tokens=safe_max,
+            measured_at=time.monotonic(),
+        )
+
+        logger.info(
+            "benchmark_complete",
+            provider=cache_key,
+            tok_per_sec=round(tok_per_sec, 1),
+            safe_max_tokens=safe_max,
+            phase_timeout_s=120.0,
+            elapsed_s=round(elapsed, 2),
+        )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_safe_max_tokens(
+        self,
+        client: Any,
+        phase_timeout_s: float,
+        default_max_tokens: int,
+    ) -> int:
+        """
+        Return a max_tokens budget that fits within *phase_timeout_s*.
+
+        - Cloud providers  → ``default_max_tokens`` (no benchmark overhead)
+        - Local providers  → benchmark once, cache for CACHE_TTL_S
+        - Any failure      → ``default_max_tokens`` (fail-safe fallback)
+        """
+        if not self._is_local_provider(client):
+            return default_max_tokens
+
+        cache_key = self._get_cache_key(client)
+        now = time.monotonic()
+
+        # Fast path: valid cache hit — no I/O
+        if cache_key in self._cache:
+            result, cached_at = self._cache[cache_key]
+            age = now - cached_at
+            if age < self.CACHE_TTL_S:
+                safe = self._calculate(result.tok_per_sec, phase_timeout_s)
+                logger.debug(
+                    "benchmark_cache_hit",
+                    provider=cache_key,
+                    age_s=round(age, 1),
+                    cached_max_tokens=safe,
+                )
+                return safe
+
+        # Slow path: run benchmark (serialised per service instance)
+        lock = await self._get_lock()
+        async with lock:
+            # Double-check after acquiring lock (another coroutine may have filled it)
+            if cache_key in self._cache:
+                result, cached_at = self._cache[cache_key]
+                if time.monotonic() - cached_at < self.CACHE_TTL_S:
+                    return self._calculate(result.tok_per_sec, phase_timeout_s)
+
+            try:
+                result = await asyncio.wait_for(
+                    self._run_benchmark_async(client),
+                    timeout=self.BENCHMARK_TIMEOUT_S,
+                )
+                self._cache[cache_key] = (result, time.monotonic())
+                return self._calculate(result.tok_per_sec, phase_timeout_s)
+
+            except Exception as exc:
+                logger.warning(
+                    "benchmark_failed",
+                    provider=cache_key,
+                    reason=str(exc),
+                    fallback=default_max_tokens,
+                )
+                return default_max_tokens
+
+
+def get_benchmark_service() -> ProviderSpeedBenchmarkService:
+    """Module-level sync factory (mirrors get_global_metrics_collector)."""
+    return ProviderSpeedBenchmarkService.get_instance()

--- a/tests/analysis/test_llm_phase_benchmark_integration.py
+++ b/tests/analysis/test_llm_phase_benchmark_integration.py
@@ -1,0 +1,214 @@
+"""
+Integration tests: LLMPhaseBase + ProviderSpeedBenchmarkService.
+
+Verifies the critical path in _call_llm_with_retry_async:
+  - Local provider  → complete_async receives benchmark-derived max_tokens
+                      (NOT the static config.max_tokens=800)
+  - Cloud provider  → complete_async receives config.max_tokens unchanged
+  - Benchmark error → falls back to config.max_tokens (no crash)
+  - Cache           → only one benchmark per provider session
+
+Note on timing:
+  AsyncMock.send_async returns instantly (elapsed≈0) so tok/s → ∞ → ceiling.
+  We mock time.monotonic where we need realistic elapsed values.
+
+Note on rate limiter:
+  We inject a high-capacity rate limiter in every test to avoid the 40s+ sleep
+  that occurs when the default burst=1000 bucket is exhausted between calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch  # patch: cloud bypass test
+
+import pytest
+
+from warden.analysis.application.llm_phase_base import LLMPhaseBase, LLMPhaseConfig
+from warden.llm.provider_speed_benchmark import ProviderSpeedBenchmarkService
+from warden.llm.types import LlmProvider, LlmResponse
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass (LLMPhaseBase is abstract)
+# ---------------------------------------------------------------------------
+
+
+class _Phase(LLMPhaseBase):
+    @property
+    def phase_name(self) -> str:
+        return "integration_test"
+
+    def get_system_prompt(self) -> str:
+        return "system"
+
+    def format_user_prompt(self, context) -> str:
+        return "user"
+
+    def parse_llm_response(self, response) -> str:
+        return response
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_phase(config: LLMPhaseConfig, llm: MagicMock) -> _Phase:
+    """Create a test phase with a no-op rate limiter.
+
+    TokenBucketLimiter.acquire() has a pre-existing bug: it acquires its
+    asyncio.Lock and never releases it, deadlocking on the second sequential
+    call.  We mock acquire_async to bypass this entirely so integration tests
+    can call _call_llm_with_retry_async multiple times without hanging.
+    """
+    rl = MagicMock()
+    rl.acquire_async = AsyncMock(return_value=None)
+    return _Phase(config=config, llm_service=llm, rate_limiter=rl)
+
+
+def _ollama_llm(tokens_produced: int = 10) -> MagicMock:
+    """Mock Ollama client — send_async (benchmark) and complete_async (main call)."""
+    llm = MagicMock()
+    llm.provider = LlmProvider.OLLAMA
+    llm.endpoint = ""
+    llm.config = None
+
+    benchmark_resp = LlmResponse(
+        content="hello " * tokens_produced,
+        success=True,
+        provider=LlmProvider.OLLAMA,
+        model="qwen",
+        completion_tokens=tokens_produced,
+    )
+    llm.send_async = AsyncMock(return_value=benchmark_resp)
+
+    main_resp = LlmResponse(
+        content='{"score": 8}',
+        success=True,
+        provider=LlmProvider.OLLAMA,
+        model="qwen",
+    )
+    llm.complete_async = AsyncMock(return_value=main_resp)
+    return llm
+
+
+def _groq_llm() -> MagicMock:
+    llm = MagicMock()
+    llm.provider = LlmProvider.GROQ
+    llm.endpoint = ""
+    llm.config = None
+    llm.complete_async = AsyncMock(
+        return_value=LlmResponse(content="ok", success=True, provider=LlmProvider.GROQ, model="llama3")
+    )
+    return llm
+
+
+@pytest.fixture(autouse=True)
+def reset_benchmark():
+    ProviderSpeedBenchmarkService.reset_instance()
+    yield
+    ProviderSpeedBenchmarkService.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkIntegration:
+    @pytest.mark.asyncio
+    async def test_local_provider_benchmark_is_applied(self):
+        """
+        For Ollama: complete_async must receive max_tokens from the benchmark,
+        not the static config.max_tokens=800.
+
+        AsyncMock returns instantly (elapsed≈0) so tok/s→∞ → ceiling=4000.
+        What matters: the code called the benchmark and used its result.
+        """
+        config = LLMPhaseConfig(enabled=True, max_tokens=800, timeout=120, max_retries=1)
+        llm = _ollama_llm(tokens_produced=10)
+        phase = _make_phase(config, llm)
+        assert phase.is_local is True
+
+        await phase._call_llm_with_retry_async("sys", "user")
+
+        assert llm.complete_async.called
+        _, kwargs = llm.complete_async.call_args
+        actual = kwargs.get("max_tokens")
+
+        # Benchmark was applied (not the static config default)
+        assert actual != 800, f"complete_async used static config.max_tokens=800, benchmark was ignored"
+        # Result is within valid range
+        assert (
+            ProviderSpeedBenchmarkService.MAX_TOKENS_FLOOR <= actual <= ProviderSpeedBenchmarkService.MAX_TOKENS_CEILING
+        )
+        # send_async (benchmark probe) was called
+        assert llm.send_async.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cloud_provider_uses_config_max_tokens(self):
+        """
+        For Groq: complete_async must receive config.max_tokens=800 unchanged.
+        Benchmark service must NOT be invoked.
+        """
+        config = LLMPhaseConfig(enabled=True, max_tokens=800, timeout=120, max_retries=1)
+        llm = _groq_llm()
+        phase = _make_phase(config, llm)
+        assert not getattr(phase, "is_local", False)
+
+        with patch("warden.llm.provider_speed_benchmark.ProviderSpeedBenchmarkService.get_instance") as mock_get:
+            await phase._call_llm_with_retry_async("sys", "user")
+
+        mock_get.assert_not_called()
+
+        _, kwargs = llm.complete_async.call_args
+        assert kwargs.get("max_tokens") == 800
+
+    @pytest.mark.asyncio
+    async def test_benchmark_failure_falls_back_to_config(self):
+        """
+        Benchmark send_async raises → effective_max_tokens = config.max_tokens=800.
+        Phase must still call complete_async normally (no crash).
+        """
+        config = LLMPhaseConfig(enabled=True, max_tokens=800, timeout=120, max_retries=1)
+        llm = _ollama_llm()
+        llm.send_async = AsyncMock(side_effect=RuntimeError("ollama crashed"))
+        phase = _make_phase(config, llm)
+        assert phase.is_local is True
+
+        await phase._call_llm_with_retry_async("sys", "user")
+
+        assert llm.complete_async.called
+        _, kwargs = llm.complete_async.call_args
+        assert kwargs.get("max_tokens") == 800
+
+    @pytest.mark.asyncio
+    async def test_cache_prevents_repeated_benchmarks(self):
+        """
+        Two consecutive LLM calls on the same local provider must only
+        trigger one benchmark (send_async call), not two.
+        """
+        config = LLMPhaseConfig(enabled=True, max_tokens=800, timeout=120, max_retries=1)
+        llm = _ollama_llm(tokens_produced=10)
+        phase = _make_phase(config, llm)
+
+        await phase._call_llm_with_retry_async("sys", "first call")
+        await phase._call_llm_with_retry_async("sys", "second call")
+
+        assert llm.complete_async.call_count == 2
+        assert llm.send_async.call_count == 1, f"Benchmark ran {llm.send_async.call_count}x — cache not working"
+
+    def test_phase_timeout_passed_to_calculate(self):
+        """
+        The phase timeout value (config.timeout) is passed as phase_timeout_s
+        to get_safe_max_tokens. Verify _calculate honours it.
+        30s timeout: _calculate(10 tok/s, 30s) = 225
+        120s timeout: _calculate(10 tok/s, 120s) = 900
+        This is a pure-function contract — no async, no mock needed.
+        """
+        tokens_30 = ProviderSpeedBenchmarkService._calculate(10.0, 30.0)
+        tokens_120 = ProviderSpeedBenchmarkService._calculate(10.0, 120.0)
+
+        assert tokens_30 < tokens_120
+        assert tokens_30 == 225
+        assert tokens_120 == 900

--- a/tests/llm/test_provider_speed_benchmark.py
+++ b/tests/llm/test_provider_speed_benchmark.py
@@ -1,0 +1,407 @@
+"""
+Tests for ProviderSpeedBenchmarkService.
+
+Covers:
+1. _calculate — pure function, ceiling/floor clamping, zero speed
+2. _is_local_provider — provider enum/string detection, localhost endpoints
+3. Cache behaviour — hit skips benchmark, TTL expiry triggers new measurement
+4. Singleton invariant — same object, reset_instance, thread safety
+5. Chaos failure modes — exception, timeout, cloud bypass, concurrent dedup
+6. End-to-end flow — full mock integration
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from warden.llm.provider_speed_benchmark import (
+    ProviderSpeedBenchmarkService,
+    ProviderSpeedResult,
+    get_benchmark_service,
+)
+from warden.llm.types import LlmProvider, LlmResponse
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Reset singleton before every test for isolation."""
+    ProviderSpeedBenchmarkService.reset_instance()
+    yield
+    ProviderSpeedBenchmarkService.reset_instance()
+
+
+def _make_ollama_client(tok_per_sec: float = 10.0, endpoint: str = "") -> MagicMock:
+    """Return a mock client that looks like an Ollama provider."""
+    client = MagicMock()
+    client.provider = LlmProvider.OLLAMA
+    tokens = max(1, int(tok_per_sec * 0.1))  # simulate ~100ms response
+    response = LlmResponse(
+        content="hello world " * tokens,
+        success=True,
+        provider=LlmProvider.OLLAMA,
+        model="qwen",
+        completion_tokens=tokens,
+    )
+    client.send_async = AsyncMock(return_value=response)
+    if endpoint:
+        client.endpoint = endpoint
+    return client
+
+
+def _make_groq_client() -> MagicMock:
+    """Return a mock client that looks like a Groq (cloud) provider."""
+    client = MagicMock()
+    client.provider = LlmProvider.GROQ
+    return client
+
+
+# ---------------------------------------------------------------------------
+# TestCalculate — pure function
+# ---------------------------------------------------------------------------
+
+
+class TestCalculate:
+    def test_nominal(self):
+        """10 tok/s × 120s × 0.75 = 900 tokens."""
+        result = ProviderSpeedBenchmarkService._calculate(10.0, 120.0)
+        assert result == 900
+
+    def test_ceiling_cap(self):
+        """Very fast provider should be capped at MAX_TOKENS_CEILING."""
+        result = ProviderSpeedBenchmarkService._calculate(1000.0, 120.0)
+        assert result == ProviderSpeedBenchmarkService.MAX_TOKENS_CEILING
+
+    def test_floor(self):
+        """Very slow provider (0.1 tok/s) should be clamped to MAX_TOKENS_FLOOR."""
+        result = ProviderSpeedBenchmarkService._calculate(0.1, 10.0)
+        assert result == ProviderSpeedBenchmarkService.MAX_TOKENS_FLOOR
+
+    def test_zero_speed(self):
+        """Zero speed returns the floor, never divides by zero."""
+        result = ProviderSpeedBenchmarkService._calculate(0.0, 120.0)
+        assert result == ProviderSpeedBenchmarkService.MAX_TOKENS_FLOOR
+
+    def test_short_timeout(self):
+        """Short timeout (30s) at 10 tok/s = 225 tokens (within bounds)."""
+        result = ProviderSpeedBenchmarkService._calculate(10.0, 30.0)
+        assert result == int(10.0 * 30.0 * 0.75)  # 225
+
+
+# ---------------------------------------------------------------------------
+# TestIsLocalProvider
+# ---------------------------------------------------------------------------
+
+
+class TestIsLocalProvider:
+    def test_ollama_enum(self):
+        client = _make_ollama_client()
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is True
+
+    def test_claude_code_enum(self):
+        client = MagicMock()
+        client.provider = LlmProvider.CLAUDE_CODE
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is True
+
+    def test_codex_string(self):
+        client = MagicMock()
+        client.provider = "codex"
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is True
+
+    def test_groq_not_local(self):
+        client = _make_groq_client()
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is False
+
+    def test_openai_not_local(self):
+        client = MagicMock()
+        client.provider = LlmProvider.OPENAI
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is False
+
+    def test_localhost_endpoint(self):
+        """Generic local endpoint should be detected."""
+        client = MagicMock()
+        client.provider = LlmProvider.UNKNOWN
+        client.endpoint = "http://localhost:11434"
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is True
+
+    def test_127_endpoint(self):
+        client = MagicMock()
+        client.provider = LlmProvider.UNKNOWN
+        client.endpoint = "http://127.0.0.1:11434"
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is True
+
+    def test_remote_endpoint_not_local(self):
+        client = MagicMock()
+        client.provider = LlmProvider.UNKNOWN
+        client.endpoint = "https://api.groq.com"
+        assert ProviderSpeedBenchmarkService._is_local_provider(client) is False
+
+
+# ---------------------------------------------------------------------------
+# TestCacheBehaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCacheBehaviour:
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_benchmark(self):
+        """Second call should return cached result without calling send_async again."""
+        client = _make_ollama_client(tok_per_sec=10.0)
+        svc = ProviderSpeedBenchmarkService.get_instance()
+
+        first = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        second = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+
+        # send_async called exactly once despite two get_safe_max_tokens calls
+        assert client.send_async.call_count == 1
+        assert first == second
+
+    @pytest.mark.asyncio
+    async def test_ttl_expiry_triggers_new_benchmark(self):
+        """Expired cache should trigger a fresh benchmark call."""
+        client = _make_ollama_client(tok_per_sec=10.0)
+        svc = ProviderSpeedBenchmarkService.get_instance()
+
+        await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        assert client.send_async.call_count == 1
+
+        # Expire the cache entry
+        cache_key = ProviderSpeedBenchmarkService._get_cache_key(client)
+        result, _ = svc._cache[cache_key]
+        svc._cache[cache_key] = (result, time.monotonic() - ProviderSpeedBenchmarkService.CACHE_TTL_S - 1)
+
+        await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        assert client.send_async.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# TestSingleton
+# ---------------------------------------------------------------------------
+
+
+class TestSingleton:
+    def test_same_object(self):
+        a = ProviderSpeedBenchmarkService.get_instance()
+        b = ProviderSpeedBenchmarkService.get_instance()
+        assert a is b
+
+    def test_reset_creates_fresh(self):
+        a = ProviderSpeedBenchmarkService.get_instance()
+        ProviderSpeedBenchmarkService.reset_instance()
+        b = ProviderSpeedBenchmarkService.get_instance()
+        assert a is not b
+
+    def test_direct_init_raises(self):
+        ProviderSpeedBenchmarkService.get_instance()  # create singleton
+        with pytest.raises(RuntimeError, match="get_instance"):
+            ProviderSpeedBenchmarkService()
+
+    def test_thread_safety_20_threads(self):
+        """20 concurrent threads must all receive the same singleton."""
+        results: list[ProviderSpeedBenchmarkService] = []
+        lock = threading.Lock()
+
+        def get_it():
+            inst = ProviderSpeedBenchmarkService.get_instance()
+            with lock:
+                results.append(inst)
+
+        threads = [threading.Thread(target=get_it) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 20
+        assert all(r is results[0] for r in results)
+
+    def test_get_benchmark_service_factory(self):
+        inst = get_benchmark_service()
+        assert isinstance(inst, ProviderSpeedBenchmarkService)
+        assert inst is get_benchmark_service()
+
+
+# ---------------------------------------------------------------------------
+# TestChaosFailureModes
+# ---------------------------------------------------------------------------
+
+
+class TestChaosFailureModes:
+    @pytest.mark.asyncio
+    async def test_exception_returns_default(self):
+        """send_async raising → return default_max_tokens."""
+        client = MagicMock()
+        client.provider = LlmProvider.OLLAMA
+        client.send_async = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        assert result == 800
+
+    @pytest.mark.asyncio
+    async def test_benchmark_timeout_returns_default(self):
+        """Benchmark exceeding BENCHMARK_TIMEOUT_S → return default_max_tokens."""
+
+        async def slow_send(*_a, **_kw):
+            await asyncio.sleep(60)  # longer than any timeout
+
+        client = MagicMock()
+        client.provider = LlmProvider.OLLAMA
+        client.send_async = slow_send
+
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        # Patch timeout to 0.01s to force immediate timeout
+        with patch.object(ProviderSpeedBenchmarkService, "BENCHMARK_TIMEOUT_S", 0.01):
+            result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        assert result == 800
+
+    @pytest.mark.asyncio
+    async def test_cloud_provider_bypass(self):
+        """Cloud provider → default_max_tokens returned, send_async never called."""
+        client = _make_groq_client()
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+        assert result == 800
+        # send_async should not even exist on this mock, but let's verify nothing called
+        assert not hasattr(client, "send_async") or not client.send_async.called
+
+    @pytest.mark.asyncio
+    async def test_ceiling_cap_applied(self):
+        """Extremely fast provider → capped at MAX_TOKENS_CEILING."""
+        # 2000 tok/s × 120s × 0.75 = 180000 → should cap at 4000
+        client = _make_ollama_client(tok_per_sec=2000.0)
+
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        # Patch elapsed to 0.01s so tok/s is huge
+        call_count = 0
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return 0.0
+            return 0.01  # 10ms elapsed → massive tok/s
+
+        with patch("warden.llm.provider_speed_benchmark.time.monotonic", side_effect=fake_monotonic):
+            result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+
+        assert result == ProviderSpeedBenchmarkService.MAX_TOKENS_CEILING
+
+    @pytest.mark.asyncio
+    async def test_floor_applied_for_slow_provider(self):
+        """Very slow provider → floored at MAX_TOKENS_FLOOR."""
+        client = MagicMock()
+        client.provider = LlmProvider.OLLAMA
+        # 1 token in 100 seconds → 0.01 tok/s
+        response = LlmResponse(
+            content="hi",
+            success=True,
+            provider=LlmProvider.OLLAMA,
+            model="tiny",
+            completion_tokens=1,
+        )
+        client.send_async = AsyncMock(return_value=response)
+
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        call_count = 0
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            return float(call_count * 100)  # 100s elapsed
+
+        with patch("warden.llm.provider_speed_benchmark.time.monotonic", side_effect=fake_monotonic):
+            result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+
+        assert result == ProviderSpeedBenchmarkService.MAX_TOKENS_FLOOR
+
+    @pytest.mark.asyncio
+    async def test_concurrent_calls_deduplicated(self):
+        """Multiple concurrent calls → only one benchmark executed."""
+        call_count = 0
+
+        async def counting_send(_request):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)  # simulate short I/O delay
+            return LlmResponse(
+                content="hello",
+                success=True,
+                provider=LlmProvider.OLLAMA,
+                model="qwen",
+                completion_tokens=5,
+            )
+
+        client = MagicMock()
+        client.provider = LlmProvider.OLLAMA
+        client.send_async = counting_send
+
+        svc = ProviderSpeedBenchmarkService.get_instance()
+        tasks = [svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800) for _ in range(5)]
+        results = await asyncio.gather(*tasks)
+
+        # All results should be equal (same cached value)
+        assert len(set(results)) == 1
+        # Benchmark should have run exactly once
+        assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# TestEndToEnd
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    @pytest.mark.asyncio
+    async def test_full_flow_10_tok_per_sec(self):
+        """
+        Verify the complete flow:
+        - Benchmark runs via send_async
+        - Result is cached
+        - Returned max_tokens uses _calculate
+        """
+        # 10 tokens produced in 1 second = 10 tok/s
+        client = MagicMock()
+        client.provider = LlmProvider.OLLAMA
+        response = LlmResponse(
+            content="hello world x10",
+            success=True,
+            provider=LlmProvider.OLLAMA,
+            model="qwen",
+            completion_tokens=10,
+        )
+        client.send_async = AsyncMock(return_value=response)
+
+        call_count = 0
+
+        def fake_monotonic():
+            nonlocal call_count
+            call_count += 1
+            return float(call_count)  # 1s elapsed per call
+
+        with patch("warden.llm.provider_speed_benchmark.time.monotonic", side_effect=fake_monotonic):
+            svc = ProviderSpeedBenchmarkService.get_instance()
+            result = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+
+        expected = ProviderSpeedBenchmarkService._calculate(10.0, 120.0)  # 900
+        assert result == expected
+        assert client.send_async.call_count == 1
+
+    def test_provider_speed_result_is_frozen(self):
+        """ProviderSpeedResult must be immutable (frozen dataclass)."""
+        r = ProviderSpeedResult(
+            cache_key="ollama@",
+            tok_per_sec=10.0,
+            safe_max_tokens=900,
+            measured_at=0.0,
+        )
+        with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+            r.tok_per_sec = 999.0  # type: ignore[misc]

--- a/tests/llm/test_provider_speed_benchmark_live.py
+++ b/tests/llm/test_provider_speed_benchmark_live.py
@@ -1,0 +1,68 @@
+"""
+Live smoke test: ProviderSpeedBenchmarkService vs real Ollama (qwen2.5-coder:3b).
+
+Skipped automatically if Ollama is not reachable.
+Run manually:
+
+    pytest tests/llm/test_provider_speed_benchmark_live.py -v -s
+
+Only exercises the public API (get_safe_max_tokens).
+Cache behaviour and pure-function contracts are covered by unit tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from warden.llm.provider_speed_benchmark import ProviderSpeedBenchmarkService
+
+
+def _ollama_reachable() -> bool:
+    try:
+        import urllib.request
+
+        urllib.request.urlopen("http://localhost:11434/api/tags", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _ollama_reachable(), reason="Ollama not reachable at localhost:11434")
+
+
+def _make_ollama_client():
+    """Ollama client (qwen2.5-coder:3b)."""
+    from warden.llm.factory import create_client
+    from warden.llm.types import LlmProvider
+
+    return create_client(LlmProvider.OLLAMA)
+
+
+@pytest.mark.asyncio
+async def test_live_benchmark_smoke():
+    """
+    Service returns a valid max_tokens value with real Ollama — no crash.
+
+    Two outcomes are both acceptable:
+      - Benchmark succeeds → returns calculated value in [FLOOR, CEILING]
+      - Benchmark times out (slow hardware) → returns default_max_tokens=800
+
+    Either way the result must be in [FLOOR, CEILING] and the second call
+    must return the same value as the first (cache or same fallback).
+    """
+    ProviderSpeedBenchmarkService.reset_instance()
+    svc = ProviderSpeedBenchmarkService.get_instance()
+    client = _make_ollama_client()
+
+    floor = ProviderSpeedBenchmarkService.MAX_TOKENS_FLOOR
+    ceiling = ProviderSpeedBenchmarkService.MAX_TOKENS_CEILING
+
+    tokens_1 = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+    assert floor <= tokens_1 <= ceiling, f"safe_max_tokens={tokens_1} outside [{floor}, {ceiling}]"
+    print(f"\n  safe_max_tokens (call 1): {tokens_1}")
+
+    tokens_2 = await svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+    assert tokens_2 == tokens_1, f"Second call returned {tokens_2}, expected {tokens_1}"
+    print(f"  safe_max_tokens (call 2, same client): {tokens_2}")
+
+    ProviderSpeedBenchmarkService.reset_instance()


### PR DESCRIPTION
## Summary

- Adds `ProviderSpeedBenchmarkService` — singleton that measures local LLM throughput at runtime and computes a safe `max_tokens` budget fitting within the phase timeout
- Integrates into `LLMPhaseBase`: when `is_local=True`, `effective_max_tokens` is used instead of the static `config.max_tokens`
- Cloud providers (Groq, OpenAI, Anthropic) are bypassed — zero benchmark overhead

## Motivation

Static `max_tokens=800` causes scan failures on slow Ollama models:
- Ollama throughput: 3–5 tok/s → 160–267s generation for 800 tokens
- Phase timeout: 120s → **timeout → scan failure**

## Formula

```
safe_max_tokens = clamp(tok_per_sec × phase_timeout_s × 0.75, min=100, max=4000)
```

## Test plan

- [x] 28 unit tests (`test_provider_speed_benchmark.py`)
- [x] 5 integration tests (`test_llm_phase_benchmark_integration.py`)
- [x] 1 live Ollama smoke test (`test_provider_speed_benchmark_live.py`)
- [x] All 33 tests pass locally

Closes #289