### PR TITLE
fix(llm): release lock in TokenBucketLimiter.acquire()

### DIFF
--- a/src/warden/llm/rate_limiter.py
+++ b/src/warden/llm/rate_limiter.py
@@ -76,6 +76,7 @@ class TokenBucketLimiter:
                 await self._lock.acquire()
             else:
                 self.tokens -= n
+            self._lock.release()
         except Exception:
             # Ensure the lock is always released on unexpected errors
             if self._lock.locked():

--- a/tests/llm/test_rate_limiter.py
+++ b/tests/llm/test_rate_limiter.py
@@ -174,3 +174,11 @@ class TestBurstOneBugRegression:
         assert rl.token_limiter.tokens == 1
         # A 1000-token request would need to wait ~12s
         # This test documents the problem so it's caught in review
+
+    @pytest.mark.asyncio
+    async def test_sequential_acquires_do_not_deadlock(self):
+        """Lock must be released — sequential calls must complete without hanging."""
+        rl = RateLimiter(RateLimitConfig(tpm=1_000_000, rpm=1000))
+        await rl.acquire(100)
+        await rl.acquire(100)  # Deadlocked before fix
+        await rl.acquire(100)  # Triple verification


### PR DESCRIPTION
## Summary

- `TokenBucketLimiter.acquire()` was acquiring `self._lock` but never releasing it on the normal (tokens-available) path
- Every second `acquire()` call deadlocked permanently
- Added `self._lock.release()` at the end of the `try` block, covering both the `if` branch (after re-acquire post-sleep) and the `else` branch

## Root Cause

```python
await self._lock.acquire()
try:
    if self.tokens < n:
        self._lock.release()       # released before sleep ✓
        await asyncio.sleep(wait)
        await self._lock.acquire() # re-acquired after sleep ✓
    else:
        self.tokens -= n
        # ← self._lock.release() MISSING ✗
except Exception:
    ...
# lock never released on normal path
```

## Fix

One line added at the end of the `try` block:

```python
    else:
        self.tokens -= n
    self._lock.release()   # ← added
except Exception:
```

## Test plan

- [x] All 12 existing rate limiter tests pass
- [x] New regression test `test_sequential_acquires_do_not_deadlock` — three sequential `acquire()` calls must complete without hanging

Closes #291