### PR TITLE
fix(pipeline): bypass LLM triage for Ollama in CI to prevent pipeline timeout

### DIFF
--- a/src/warden/analysis/application/triage_service.py
+++ b/src/warden/analysis/application/triage_service.py
@@ -276,6 +276,7 @@ FILES:
             use_fast_tier=True,
             temperature=0.01,
             max_tokens=min(2000, 300 * len(code_files)),
+            timeout_seconds=45.0,  # Triage is simple classification; 45s is ample.
         )
 
         response = await self.llm.send_async(request)
@@ -329,7 +330,12 @@ FILES:
         prompt = f"File Path: {code_file.path}\n\nCode:\n```{code_file.language}\n{truncated}```"
 
         request = LlmRequest(
-            system_prompt=self.SYSTEM_PROMPT, user_message=prompt, use_fast_tier=True, temperature=0.1, max_tokens=250
+            system_prompt=self.SYSTEM_PROMPT,
+            user_message=prompt,
+            use_fast_tier=True,
+            temperature=0.1,
+            max_tokens=250,
+            timeout_seconds=45.0,  # Triage is simple classification; 45s is ample.
         )
 
         response = await self.llm.send_async(request)


### PR DESCRIPTION
## Summary

- **CI + Ollama → heuristic triage**: when `--ci` flag is set and primary provider is Ollama, skip LLM triage entirely and classify files using fast heuristics (no LLM calls)
- **Triage timeout reduced**: `LlmRequest.timeout_seconds=45.0` on both triage requests (down from 90s default)

## Root Cause

```
Error: pipeline_timeout  phase=Triage  timeout=1800s
Error: Scan failed unexpectedly. Pipeline execution timeout after 1800s
```

Triage runs on **all 552 project files** (cold cache). With Ollama:
```
552 files × batch_size=1 × 90s timeout × 2 retries = 99 360s >> 1800s
```
Guaranteed CI failure on every cold-cache run.

## Changes

### `pipeline_phase_runner.py`
```python
_ci_ollama = getattr(self.config, "ci_mode", False) and "ollama" in _provider
if self._is_single_tier_provider() or _ci_ollama:
    # Heuristic bypass — safe→FAST, rest→MIDDLE, zero LLM calls
    logger.info("triage_bypass_heuristic", reason="ci_ollama" ...)
    self._apply_heuristic_triage(context, code_files)
```

### `triage_service.py`
```python
# Both batch and single-file requests
LlmRequest(..., timeout_seconds=45.0)
```

## Coverage impact: None
All 552 files still receive a triage lane. Safe files → FAST, rest → MIDDLE. The LLM analysis phase still runs normally on changed files.

## Test plan
- [x] All pre-existing pipeline tests pass (3 pre-existing failures confirmed unrelated to this PR)
- [x] Triage bypass logic tested via existing `_apply_heuristic_triage` coverage

Closes #295