### PR TITLE
perf(llm): skip fast tier when fast/smart use identical Ollama model

### DIFF
--- a/src/warden/llm/factory.py
+++ b/src/warden/llm/factory.py
@@ -173,9 +173,20 @@ def create_client(provider_or_config: LlmProvider | LlmConfiguration | str | Non
             )
     else:
         for fast_provider in getattr(config, "fast_tier_providers", [LlmProvider.OLLAMA]):
-            if fast_provider == provider and fast_provider not in _LOCAL_PROVIDERS:
-                # Cloud provider is already the smart_client — skip to avoid
-                # racing against the same API quota / rate limit.
+            _same_provider = fast_provider == provider
+            _same_model = config.fast_model == config.smart_model
+            if _same_provider and (fast_provider not in _LOCAL_PROVIDERS or _same_model):
+                # Skip when:
+                # 1. Cloud provider already is the smart_client (same API quota).
+                # 2. Local provider (e.g. Ollama) uses identical model for both tiers —
+                #    racing against the same instance/model wastes the fast_timeout
+                #    (20s CI / 30s local) before falling back to the same Ollama.
+                if _same_provider:
+                    _factory_logger.info(
+                        "fast_tier_skipped_same_provider",
+                        provider=fast_provider.value,
+                        reason="identical_model" if _same_model else "cloud_quota",
+                    )
                 continue
             try:
                 fast_cfg = config.get_provider_config(fast_provider)


### PR DESCRIPTION
## Summary

- Extends fast tier deduplication in `factory.py` to cover local providers (Ollama) when `fast_model == smart_model`
- Eliminates 20s wasted `fast_timeout` per LLM call in CI where both tiers point to the same `qwen2.5-coder:3b` instance
- Logs `fast_tier_skipped_same_provider` with reason (`identical_model` vs `cloud_quota`) for observability

Closes #316

## Root Cause

`factory.py:176` previously only skipped cloud providers from the fast tier:
```python
if fast_provider == provider and fast_provider not in _LOCAL_PROVIDERS:
    continue  # local providers (Ollama) passed through
```
When CI uses `fast_model=qwen2.5-coder:3b` = `smart_model`, the fast tier raced identical requests against the same Ollama, always timing out at 20s.

## Fix

```python
_same_provider = fast_provider == provider
_same_model = config.fast_model == config.smart_model
if _same_provider and (fast_provider not in _LOCAL_PROVIDERS or _same_model):
    ...
    continue
```

## Test plan

- [ ] Unit: `test_factory.py` — verify `fast_clients=[]` when same Ollama model
- [ ] Integration: scan with `WARDEN_LLM_PROVIDER=ollama` — confirm `orchestrated_client_no_fast_tier` or `fast_tier_skipped_same_provider` in logs
- [ ] CI: verify no `all_fast_tier_providers_failed_falling_back_to_smart` warnings in scan output