### PR TITLE
perf(pipeline): switch to SEQUENTIAL strategy in CI+Ollama mode

### DIFF
--- a/src/warden/pipeline/application/orchestrator/pipeline_phase_runner.py
+++ b/src/warden/pipeline/application/orchestrator/pipeline_phase_runner.py
@@ -179,6 +179,22 @@ class PipelinePhaseRunner:
                 skipped_phases=["fortification", "cleaning", "issue_validation"],
             )
 
+            # For CPU-only local providers (Ollama), parallel frame execution
+            # provides no throughput benefit — Ollama serialises requests internally.
+            # Switch to SEQUENTIAL so asyncio.wait_for timeouts start only when
+            # a frame's requests are actually in flight, not while queued.
+            _provider = self._detect_primary_provider()
+            if "ollama" in _provider:
+                from warden.pipeline.domain.enums import ExecutionStrategy
+
+                self.config.strategy = ExecutionStrategy.SEQUENTIAL
+                self.config.parallel_limit = 1
+                logger.info(
+                    "ci_ollama_sequential_mode",
+                    provider=_provider,
+                    reason="CPU-only Ollama serialises requests; parallel frames add no throughput",
+                )
+
         # Phase 0: PRE-ANALYSIS
         context.current_phase = "Pre-Analysis"
         if self._progress_callback:


### PR DESCRIPTION
## Summary

- When `ci_mode=True` AND provider is Ollama, sets `strategy=SEQUENTIAL` and `parallel_limit=1`
- Prevents asyncio.wait_for timeouts from firing while requests are still queued in the Ollama semaphore
- Eliminates false `WARDEN-TIMEOUT` findings caused by queue delay, not actual processing slowness

Closes #317

## Test plan

- [ ] CI scan with `--ci` flag + Ollama: verify `ci_ollama_sequential_mode` log event
- [ ] No `WARDEN-TIMEOUT` findings for files that process correctly when run sequentially
- [ ] Non-CI scans: verify strategy unchanged (still PARALLEL)