### PR TITLE
ci: set WARDEN_OLLAMA_CONCURRENCY=1 and WARDEN_FILE_CONCURRENCY=1 for serial CPU Ollama

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,12 @@ jobs:
           WARDEN_LLM_PROVIDER: "ollama"
           WARDEN_BLOCKED_PROVIDERS: "claude_code,codex"
           OLLAMA_HOST: http://localhost:11434
+          # Limit Ollama concurrency to 1: CPU-only Ollama serialises requests
+          # internally; extra connections hold semaphore slots for no benefit. (#319)
+          WARDEN_OLLAMA_CONCURRENCY: "1"
+          # Limit file-level concurrency to 1: prevents asyncio.wait_for timeouts
+          # from firing while a file's request is still queued in the Ollama semaphore. (#320)
+          WARDEN_FILE_CONCURRENCY: "1"
         run: |
           # =============================================================
           # SCAN STRATEGY (both paths use Ollama)


### PR DESCRIPTION
## Summary

- `WARDEN_OLLAMA_CONCURRENCY=1`: eliminates 2 idle HTTP connections to CPU-only Ollama (Closes #319)
- `WARDEN_FILE_CONCURRENCY=1`: prevents asyncio.wait_for timeouts from firing while files are queued in the Ollama semaphore (Closes #320)

Together with #317 (SEQUENTIAL frame strategy), this ensures exactly **1 Ollama request is in-flight at any time** in CI, making timeout accounting deterministic.

## Test plan

- [ ] CI scan: verify no `WARDEN-TIMEOUT` findings for normally-processing files
- [ ] Check Ollama logs: only 1 concurrent request ever visible
- [ ] Verify `warden_file_gather` tasks complete sequentially (concurrency=1 in logs)