### PR TITLE
perf(classification): skip use_fast_tier when provider is Ollama

### DIFF
--- a/src/warden/classification/application/llm_classification_phase.py
+++ b/src/warden/classification/application/llm_classification_phase.py
@@ -166,8 +166,13 @@ class LLMClassificationPhase(LLMPhaseBase):
                 prompt = self._format_classification_batch_user_prompt(
                     project_type, framework, batch_files, file_contexts, previous_issues
                 )
+                # In CI+Ollama: fast_clients is empty after factory.py #316 fix,
+                # so use_fast_tier=True is a no-op. As defence-in-depth, detect
+                # Ollama provider directly and skip fast tier routing.
+                _provider_raw = getattr(self.llm, "provider", "")
+                _is_ollama = "ollama" in str(_provider_raw).lower()
                 response = await self._call_llm_with_retry_async(
-                    system_prompt=system_prompt, user_prompt=prompt, use_fast_tier=True
+                    system_prompt=system_prompt, user_prompt=prompt, use_fast_tier=not _is_ollama
                 )
                 if not response or not response.content:
                     raise RuntimeError("LLM returned no content after retries")


### PR DESCRIPTION
## Summary

- Classification LLM batches now detect Ollama provider and set `use_fast_tier=False`
- Defence-in-depth for #316: even if a future fast client is added with a different model, classification won't trigger the fast tier race for Ollama

Closes #321

## Why not just rely on #316?

`factory.py` #316 makes `fast_clients=[]` when `fast_model==smart_model`, making `use_fast_tier=True` a no-op in that config. This fix adds an explicit call-site guard so classification behaviour is self-documenting and safe against future config changes.

## Test plan

- [ ] CI classification logs show `use_fast_tier=False` for Ollama provider
- [ ] Non-Ollama providers (Groq, OpenAI) still use `use_fast_tier=True` (unchanged)