### PR TITLE
perf(security): add max_tokens=600 to batch_processor LlmRequest

### DIFF
--- a/src/warden/validation/frames/security/batch_processor.py
+++ b/src/warden/validation/frames/security/batch_processor.py
@@ -161,6 +161,7 @@ Return JSON array with verification results:
         request = LlmRequest(
             user_message=full_prompt,
             system_prompt="You are a senior security engineer. Verify if these security findings are true vulnerabilities or false positives.",
+            max_tokens=600,  # JSON array for 10 findings ~200-400 tok; cap prevents Ollama over-allocation
         )
         response = await llm_service.send_with_tools_async(request)
 


### PR DESCRIPTION
Fixes #329

## Problem
`batch_processor.py:161` used `LlmRequest()` without `max_tokens` → default 4000. JSON verification for 10 findings ≈ 200-400 tokens. At 5 tok/s = 80s >> 45s `per_file_timeout` → all parallel batches (asyncio.gather) time out → FP filtering silently skipped, security false positives kept.

## Fix
`max_tokens=600`: fits 10-finding JSON array and stays within 45s at CPU throughput.