### PR TITLE
perf(fuzz,spec): fix LlmRequest max_tokens to prevent CPU Ollama timeouts

### DIFF
--- a/src/warden/validation/frames/fuzz/fuzz_frame.py
+++ b/src/warden/validation/frames/fuzz/fuzz_frame.py
@@ -328,10 +328,13 @@ Output must be a valid JSON object with the following structure:
             budget = resolve_token_budget(BUDGET_FUZZ)
             truncated = prepare_code_for_llm(code_file.content, token_budget=budget)
 
+            # Reuse the safe token budget computed above for local providers; cloud gets 800.
+            _output_max = _safe if ProviderSpeedBenchmarkService._is_local_provider(client) else 800
             request = LlmRequest(
                 system_prompt=self.SYSTEM_PROMPT,
                 user_message=f"Analyze this {code_file.language} code:\n\n{truncated}{taint_context}",
                 temperature=0.1,
+                max_tokens=_output_max,
             )
 
             response = await client.send_with_tools_async(request)

--- a/src/warden/validation/frames/spec/extractors/universal_extractor.py
+++ b/src/warden/validation/frames/spec/extractors/universal_extractor.py
@@ -519,6 +519,7 @@ Extract details.
             system_prompt=get_tool_enhanced_prompt("You are a contract extraction specialist."),
             user_message=prompt,
             temperature=0.0,
+            max_tokens=250,  # Contract JSON ~100-200 tok; fits within wait_for(60s) at 5 tok/s CPU
         )
 
         try:


### PR DESCRIPTION
Fixes #335, #336

## fuzz_frame (D1)
`_safe` from `get_safe_max_tokens()` was only used as a skip-guard. `LlmRequest()` used default 4000 → 800s generation >> 45s `per_file_timeout` → zero fuzz findings in CI. Reuses `_safe` as `max_tokens` (same fix pattern as #334 for property_frame).

## universal_extractor (D2)
`LlmRequest()` default 4000 inside `asyncio.wait_for(60s)`. At 5 tok/s: 60s = 300 tokens max. Contract JSON ~100-200 tok, but under load (3 tok/s) timeout fires → all extractions fall back to heuristics silently. `max_tokens=250` caps allocation and stays within 60s.