### PR TITLE
fix(ollama): cap num_predict to benchmark-derived safe budget in send_async()

### DIFF
--- a/src/warden/analysis/application/llm_phase_base.py
+++ b/src/warden/analysis/application/llm_phase_base.py
@@ -45,6 +45,24 @@ def _apply_read_timeout(client: Any, timeout_s: float) -> None:
             fast.set_read_timeout(timeout_s)
 
 
+def _apply_safe_num_predict(client: Any, tokens: int) -> None:
+    """Propagate a benchmark-derived output-token cap to all reachable OllamaClient instances.
+
+    Mirrors _apply_read_timeout traversal so the cap reaches Ollama whether it
+    is used as a direct client, a smart-tier client, or a fast-tier client inside
+    an OrchestratedLlmClient.
+    """
+    if hasattr(client, "set_safe_num_predict"):
+        client.set_safe_num_predict(tokens)
+        return
+    smart = getattr(client, "smart_client", None)
+    if smart is not None and hasattr(smart, "set_safe_num_predict"):
+        smart.set_safe_num_predict(tokens)
+    for fast in getattr(client, "fast_clients", []):
+        if hasattr(fast, "set_safe_num_predict"):
+            fast.set_safe_num_predict(tokens)
+
+
 @dataclass
 class LLMPhaseConfig:
     """Configuration for LLM-enhanced phase."""
@@ -556,6 +574,9 @@ class LLMPhaseBase(ABC):
             cache_key = svc._get_cache_key(self.llm)
             read_timeout = svc.get_safe_read_timeout(cache_key, estimated_tokens)
             _apply_read_timeout(self.llm, read_timeout)
+            # Also propagate the phase-specific token cap so any LlmRequest that
+            # omits max_tokens is silently protected inside OllamaClient.send_async().
+            _apply_safe_num_predict(self.llm, effective_max_tokens)
 
             # If the conservative budget is too small to produce a useful response,
             # bail out immediately instead of burning self.config.max_retries × timeout

--- a/src/warden/llm/provider_speed_benchmark.py
+++ b/src/warden/llm/provider_speed_benchmark.py
@@ -311,6 +311,8 @@ class ProviderSpeedBenchmarkService:
                     age_s=round(age, 1),
                     cached_max_tokens=safe,
                 )
+                if hasattr(client, "set_safe_num_predict"):
+                    client.set_safe_num_predict(safe)
                 return safe
 
         # Slow path: run benchmark (serialised per service instance)
@@ -328,7 +330,12 @@ class ProviderSpeedBenchmarkService:
                     timeout=self.BENCHMARK_TIMEOUT_S,
                 )
                 self._cache[cache_key] = (result, time.monotonic())
-                return self._calculate(result.tok_per_sec, phase_timeout_s)
+                safe = self._calculate(result.tok_per_sec, phase_timeout_s)
+                # Propagate the phase-specific cap to the client so send_async()
+                # enforces it even when callers omit max_tokens in LlmRequest.
+                if hasattr(client, "set_safe_num_predict"):
+                    client.set_safe_num_predict(safe)
+                return safe
 
             except Exception as exc:
                 # asyncio.TimeoutError.__str__() returns '' — show type name instead.
@@ -370,6 +377,8 @@ class ProviderSpeedBenchmarkService:
                         fallback=conservative,
                         note="timeout→conservative_budget",
                     )
+                    if hasattr(client, "set_safe_num_predict"):
+                        client.set_safe_num_predict(conservative)
                     return conservative
 
                 logger.warning(

--- a/src/warden/llm/providers/ollama.py
+++ b/src/warden/llm/providers/ollama.py
@@ -53,6 +53,9 @@ class OllamaClient(ILlmClient):
         # Calibrated at scan startup once the speed benchmark completes.
         _gen_buf = ProviderSpeedBenchmarkService.BENCHMARK_TIMEOUT_S / 3
         self._read_timeout: float = ProviderSpeedBenchmarkService.BENCHMARK_TIMEOUT_S + _gen_buf
+        # Safe output-token cap: updated by set_safe_num_predict() after benchmark.
+        # Defaults to MAX_TOKENS_CEILING so behaviour is unchanged until calibrated.
+        self._safe_num_predict: int = ProviderSpeedBenchmarkService.MAX_TOKENS_CEILING
 
         logger.debug("ollama_client_initialized", endpoint=self._endpoint, default_model=self._default_model)
 
@@ -66,6 +69,17 @@ class OllamaClient(ILlmClient):
 
         floor = ProviderSpeedBenchmarkService.BENCHMARK_TIMEOUT_S / 3
         self._read_timeout = max(floor, seconds)
+
+    def set_safe_num_predict(self, tokens: int) -> None:
+        """Set the maximum output tokens Ollama will generate per request.
+
+        Called by ProviderSpeedBenchmarkService after measuring hardware throughput.
+        Acts as a hard cap in send_async(): min(request.max_tokens, self._safe_num_predict).
+        This ensures callers that omit max_tokens (default=4000) never cause a timeout
+        on CPU-only hardware regardless of which frame constructs the LlmRequest.
+        """
+        self._safe_num_predict = max(1, tokens)
+        logger.debug("ollama_safe_num_predict_set", tokens=self._safe_num_predict)
 
     @property
     def provider(self) -> LlmProvider:
@@ -115,7 +129,10 @@ class OllamaClient(ILlmClient):
                         {"role": "user", "content": request.user_message},
                     ],
                     "stream": True,
-                    "options": {"temperature": request.temperature, "num_predict": request.max_tokens},
+                    "options": {
+                        "temperature": request.temperature,
+                        "num_predict": min(request.max_tokens, self._safe_num_predict),
+                    },
                 }
                 if _wants_json:
                     payload["format"] = "json"

--- a/src/warden/validation/frames/fuzz/fuzz_frame.py
+++ b/src/warden/validation/frames/fuzz/fuzz_frame.py
@@ -300,6 +300,8 @@ Output must be a valid JSON object with the following structure:
             if ProviderSpeedBenchmarkService._is_local_provider(client):
                 _svc = get_benchmark_service()
                 _safe = await _svc.get_safe_max_tokens(client, phase_timeout_s=120.0, default_max_tokens=800)
+                if hasattr(client, "set_safe_num_predict"):
+                    client.set_safe_num_predict(_safe)
                 if _safe < _FUZZ_MIN_VIABLE_TOKENS:
                     logger.warning(
                         "llm_skipped_budget_below_viable",

--- a/src/warden/validation/frames/orphan/llm_orphan_filter.py
+++ b/src/warden/validation/frames/orphan/llm_orphan_filter.py
@@ -726,6 +726,8 @@ You have deep understanding of:
         if ProviderSpeedBenchmarkService._is_local_provider(self.llm):
             _svc = get_benchmark_service()
             _max_tokens = await _svc.get_safe_max_tokens(self.llm, phase_timeout_s=45.0, default_max_tokens=200)
+            if hasattr(self.llm, "set_safe_num_predict"):
+                self.llm.set_safe_num_predict(_max_tokens)
         else:
             _max_tokens = 600
 

--- a/src/warden/validation/frames/property/property_frame.py
+++ b/src/warden/validation/frames/property/property_frame.py
@@ -251,6 +251,8 @@ For EACH file, output a JSON object. Return a JSON array where each element corr
         if ProviderSpeedBenchmarkService._is_local_provider(self.llm_service):
             _svc = get_benchmark_service()
             _safe = await _svc.get_safe_max_tokens(self.llm_service, phase_timeout_s=120.0, default_max_tokens=800)
+            if hasattr(self.llm_service, "set_safe_num_predict"):
+                self.llm_service.set_safe_num_predict(_safe)
             if _safe < _PROPERTY_MIN_VIABLE_TOKENS:
                 logger.warning(
                     "llm_skipped_budget_below_viable",
@@ -571,6 +573,8 @@ For EACH file, output a JSON object. Return a JSON array where each element corr
             if ProviderSpeedBenchmarkService._is_local_provider(client):
                 _svc = get_benchmark_service()
                 _output_max = await _svc.get_safe_max_tokens(client, phase_timeout_s=45.0, default_max_tokens=400)
+                if hasattr(client, "set_safe_num_predict"):
+                    client.set_safe_num_predict(_output_max)
             else:
                 _output_max = 800
 

--- a/src/warden/validation/frames/resilience/resilience_frame.py
+++ b/src/warden/validation/frames/resilience/resilience_frame.py
@@ -907,6 +907,8 @@ Identify external dependencies and missing resilience patterns. Return JSON."""
                 _safe_tokens = await _svc.get_safe_max_tokens(
                     self.llm_service, phase_timeout_s=self._timeout, default_max_tokens=200
                 )
+                if hasattr(self.llm_service, "set_safe_num_predict"):
+                    self.llm_service.set_safe_num_predict(_safe_tokens)
             else:
                 _safe_tokens = 800
 


### PR DESCRIPTION
Fixes #338

## Root Cause
Every `LlmRequest()` caller had to manually pass a safe `max_tokens`. When any frame forgot (stale_sync, async_race, future frames), Ollama received `num_predict=4000` and always timed out on CPU hardware (800s vs 45s timeout).

## Fix
`OllamaClient._safe_num_predict` (default: `MAX_TOKENS_CEILING=4000`). `send_async()` now sends:
```python
num_predict = min(request.max_tokens, self._safe_num_predict)
```

## Propagation (3 paths, all use `hasattr` guard — cloud providers unaffected)

| Path | When |
|------|------|
| `ProviderSpeedBenchmarkService.get_safe_max_tokens()` | cache hit, cache miss, timeout fallback |
| `LlmPhaseBase._apply_safe_num_predict()` | after every `analyze_with_llm_async()` benchmark call |
| Frame-level direct calls | resilience, fuzz, orphan, property frames |

## Effect
- `stale_sync_frame`, `async_race_frame`, any future frame that omits `max_tokens` → **automatically protected** once benchmark runs
- Cloud providers → **no change**