### PR TITLE
perf(pre-analysis): use get_safe_max_tokens in LlmContextAnalyzer batch calls

### DIFF
--- a/src/warden/analysis/application/llm_context_analyzer.py
+++ b/src/warden/analysis/application/llm_context_analyzer.py
@@ -464,10 +464,20 @@ Return JSON:
             # Acquire rate limit before sending
             await self.rate_limiter.acquire_async(estimated_tokens)
 
+        from warden.llm.provider_speed_benchmark import ProviderSpeedBenchmarkService
+
+        _svc = ProviderSpeedBenchmarkService.get_instance()
+        # Phase 0 runs before the benchmark is calibrated by Phase 1 frames.
+        # Calling get_safe_max_tokens() here triggers the benchmark once and
+        # propagates _safe_num_predict so all subsequent Phase 0 calls are protected.
+        _max_tokens = await _svc.get_safe_max_tokens(self.llm, phase_timeout_s=90.0, default_max_tokens=400)
+        if hasattr(self.llm, "set_safe_num_predict"):
+            self.llm.set_safe_num_predict(_max_tokens)
+
         request = LlmRequest(
             system_prompt="You are an expert code analyzer. Analyze multiple files efficiently and accurately.",
             user_message=batch_prompt,
-            max_tokens=2000,
+            max_tokens=_max_tokens,
             temperature=0.0,
             use_fast_tier=True,  # Use local Qwen for batch analysis
         )


### PR DESCRIPTION
## Summary

Fixes #340

`LlmContextAnalyzer._call_llm_batch_async()` used `max_tokens=2000` with `use_fast_tier=True` (Ollama). This runs in **Phase 0** before the speed benchmark calibrates `_safe_num_predict`, so the root-fix cap in `OllamaClient.send_async()` (`min(request.max_tokens, self._safe_num_predict)`) did not protect it.

At CPU Ollama ~5 tok/s: 2000 tok = 400s >> 120s `@resilient` timeout → each sub-batch of 20 files timed out, wasting 120s per batch.

## Changes

- `_call_llm_batch_async()`: call `get_safe_max_tokens(phase_timeout_s=90.0, default=400)` before `LlmRequest`
- This triggers the benchmark on first call, calibrates `_safe_num_predict` for all subsequent Phase 0 LLM calls
- `set_safe_num_predict()` propagated to the client for immediate protection

## Test plan

- [ ] 34 pre-analysis tests pass (verified locally)
- [ ] `--level standard` + Ollama: Phase 0 no longer times out per batch
- [ ] Cloud providers unaffected (`get_safe_max_tokens` returns `default_max_tokens` for non-local)