### PR TITLE
perf(pre-analysis): use get_safe_max_tokens in ProjectPurposeDetector

### DIFF
--- a/src/warden/analysis/application/project_purpose_detector.py
+++ b/src/warden/analysis/application/project_purpose_detector.py
@@ -167,10 +167,19 @@ Return strictly JSON:
 }}"""
 
         try:
+            from warden.llm.provider_speed_benchmark import ProviderSpeedBenchmarkService
+
+            _svc = ProviderSpeedBenchmarkService.get_instance()
+            # Phase 0 runs before the benchmark calibrates _safe_num_predict.
+            # Trigger it here so the cap is active for this and all subsequent calls.
+            _max_tokens = await _svc.get_safe_max_tokens(self.llm, phase_timeout_s=90.0, default_max_tokens=400)
+            if hasattr(self.llm, "set_safe_num_predict"):
+                self.llm.set_safe_num_predict(_max_tokens)
+
             request = LlmRequest(
                 system_prompt="You are an expert system architect and security analyst. Analyze project structure to provide semantic context, assess security risk levels, and detect structural drift or ambiguity.",
                 user_message=prompt,
-                max_tokens=1200,  # Increased for enhanced output
+                max_tokens=_max_tokens,
                 temperature=0.0,
                 use_fast_tier=True,  # Use local Qwen for cost optimization
             )


### PR DESCRIPTION
## Summary

Fixes #341

`ProjectPurposeDetector.detect_async()` used `max_tokens=1200` with `use_fast_tier=True` (Ollama) in Phase 0, before the benchmark calibrates `_safe_num_predict`. 1200 tok @ 5 tok/s = 240s >> 120s `@resilient` timeout → wasted 120s, fell back to `"Warden-initialized project"`.

## Changes

- Before `LlmRequest`, call `get_safe_max_tokens(phase_timeout_s=90.0, default=400)`
- Triggers benchmark on first Phase 0 LLM call; calibrates `_safe_num_predict` for all subsequent calls
- `set_safe_num_predict()` propagated for immediate protection

## Test plan

- [ ] Pre-analysis tests pass
- [ ] `--level standard` + Ollama: purpose detection no longer times out
- [ ] Cloud providers: `default_max_tokens=400` returned immediately (no benchmark overhead)