### PR TITLE
perf(pre-analysis): use get_safe_max_tokens in ServiceAbstractionDetector

### DIFF
--- a/src/warden/analysis/application/service_abstraction_detector.py
+++ b/src/warden/analysis/application/service_abstraction_detector.py
@@ -474,10 +474,19 @@ Return strictly JSON:
 }}"""
 
         try:
+            from warden.llm.provider_speed_benchmark import ProviderSpeedBenchmarkService
+
+            _svc = ProviderSpeedBenchmarkService.get_instance()
+            # Phase 0 runs before the benchmark calibrates _safe_num_predict.
+            # Trigger it here so the cap is active for this and all subsequent calls.
+            _max_tokens = await _svc.get_safe_max_tokens(self.llm, phase_timeout_s=90.0, default_max_tokens=300)
+            if hasattr(self.llm, "set_safe_num_predict"):
+                self.llm.set_safe_num_predict(_max_tokens)
+
             request = LlmRequest(
                 system_prompt="You are an expert security and architectural analyzer. Help identify when developers bypass project-specific abstractions.",
                 user_message=prompt,
-                max_tokens=1000,
+                max_tokens=_max_tokens,
                 temperature=0.0,
             )
 


### PR DESCRIPTION
## Summary

Fixes #342

`ServiceAbstractionDetector._synthesize_bypass_rules_async()` used `max_tokens=1000` (smart tier, Ollama) in Phase 0. 1000 tok @ 5 tok/s = 200s >> 120s `@resilient` timeout → wasted 120s on cold cache runs. `--level basic` was already protected (`self.llm = None`); `--level standard` + Ollama was not.

## Changes

- Before `LlmRequest`, call `get_safe_max_tokens(phase_timeout_s=90.0, default=300)`
- `default_max_tokens=300`: compact bypass JSON (2-3 services × 2-3 patterns) fits in 300 tokens
- Triggers benchmark on first call; calibrates `_safe_num_predict` for subsequent Phase 0 calls
- `set_safe_num_predict()` propagated for immediate protection

## Test plan

- [ ] Pre-analysis tests pass
- [ ] `--level standard` + Ollama + cold cache: no longer times out
- [ ] Cache hit path: LLM call skipped entirely (unchanged)
- [ ] Cloud providers: `default_max_tokens=300` returned immediately