### PR TITLE
ci(baseline): normalize tag push cache key to 'main' (#346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .warden/baseline.sarif
-          key: warden-baseline-${{ github.ref_name }}-${{ hashFiles('pyproject.toml') }}
+          key: warden-baseline-${{ contains(github.ref, 'refs/tags/') && 'main' || github.ref_name }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            warden-baseline-${{ github.ref_name }}-
             warden-baseline-main-
+            warden-baseline-dev-
 
       # Verify Code Intelligence disabled in CI: warden refresh --force runs
       # tree-sitter AST analysis on all 557 files before Ollama is ready,


### PR DESCRIPTION
## Summary

- Tag pushes produce a unique `ref_name` (e.g. `v2.5.1`) → always cache miss → full scan (~15-20 min)
- Normalize tag pushes to `main` so they reuse the existing baseline
- Add stable `restore-keys` (`main` then `dev`) for branch PR fallback

## Change

```yaml
# Before
key: warden-baseline-${{ github.ref_name }}-${{ hashFiles('pyproject.toml') }}
restore-keys: |
  warden-baseline-${{ github.ref_name }}-
  warden-baseline-main-

# After
key: warden-baseline-${{ contains(github.ref, 'refs/tags/') && 'main' || github.ref_name }}-${{ hashFiles('pyproject.toml') }}
restore-keys: |
  warden-baseline-main-
  warden-baseline-dev-
```

## Test plan
- [ ] Tag push uses `main` key → restores cached baseline → incremental scan
- [ ] PR on `dev` uses `dev` key as before
- [ ] `restore-keys` falls back from `main` → `dev` on fresh envs

Closes #346