### PR TITLE
fix(benchmark): call set_safe_num_predict on non-timeout errors (#348)

### DIFF
--- a/src/warden/llm/provider_speed_benchmark.py
+++ b/src/warden/llm/provider_speed_benchmark.py
@@ -386,7 +386,10 @@ class ProviderSpeedBenchmarkService:
                     provider=cache_key,
                     reason=reason,
                     fallback=default_max_tokens,
+                    note="error→config_fallback",
                 )
+                if hasattr(client, "set_safe_num_predict"):
+                    client.set_safe_num_predict(default_max_tokens)
                 return default_max_tokens
 
 


### PR DESCRIPTION
## Summary

- Non-timeout benchmark exceptions (crash, network error) left `_safe_num_predict` at the default 4000, bypassing the guard against CPU-Ollama timeouts
- For timeout errors: conservative budget is computed and applied (existing behavior)
- For non-timeout errors: return `default_max_tokens` unchanged, but also call `set_safe_num_predict(default_max_tokens)` to sync the OllamaClient guard

## Before / After

```python
# Before — _safe_num_predict never updated on non-timeout
logger.warning('benchmark_failed', reason=reason, fallback=default_max_tokens)
return default_max_tokens

# After — syncs OllamaClient guard even on non-timeout errors
logger.warning('benchmark_failed', ..., note='error→config_fallback')
if hasattr(client, 'set_safe_num_predict'):
    client.set_safe_num_predict(default_max_tokens)
return default_max_tokens
```

## Test plan
- [x] All 45 benchmark tests pass
- [x] `test_benchmark_failure_falls_back_to_config` still passes (behavior unchanged)
- [x] `set_safe_num_predict` is now called on crash/network error paths

Closes #348