### PR TITLE
fix(frames): correct invalid Finding severity values in gitchanges and spec frames (#352)

### DIFF
--- a/src/warden/validation/frames/gitchanges/gitchanges_frame.py
+++ b/src/warden/validation/frames/gitchanges/gitchanges_frame.py
@@ -301,7 +301,7 @@ class GitChangesFrame(ValidationFrame):
             # For now, we just report that the line was changed
             finding = Finding(
                 id=f"{self.frame_id}-line-{line_num}",
-                severity="info",
+                severity="low",
                 message=f"Line {line_num} was added or modified",
                 location=f"{code_file.path}:{line_num}",
                 detail="This line was detected as changed in git diff",
@@ -313,7 +313,7 @@ class GitChangesFrame(ValidationFrame):
         if added_lines:
             summary_finding = Finding(
                 id=f"{self.frame_id}-summary",
-                severity="info",
+                severity="low",
                 message=f"Git changes detected: {len(added_lines)} lines added/modified",
                 location=f"{code_file.path}:1",
                 detail=self._create_summary_detail(file_diff, added_lines),

--- a/src/warden/validation/frames/spec/spec_frame.py
+++ b/src/warden/validation/frames/spec/spec_frame.py
@@ -476,7 +476,7 @@ class SpecFrame(ValidationFrame, Cleanable, ProjectContextAware):
                         # Create warning finding for timeout
                         timeout_finding = Finding(
                             id=f"{self.frame_id}-timeout-{consumer.name}-{provider.name}",
-                            severity="warning",
+                            severity="medium",
                             message=f"Gap analysis timed out comparing {consumer.name} vs {provider.name}",
                             location="project-level",
                             detail=f"Analysis exceeded {gap_analysis_timeout}s timeout. "

--- a/tests/validation/frames/gitchanges/test_gitchanges_frame.py
+++ b/tests/validation/frames/gitchanges/test_gitchanges_frame.py
@@ -15,18 +15,20 @@ from unittest.mock import Mock, patch
 from warden.validation.domain.frame import CodeFile, FrameResult
 import sys
 
+
 @pytest.fixture(scope="module")
 def gitchanges_components():
     from warden.validation.infrastructure.frame_registry import FrameRegistry
+
     registry = FrameRegistry()
     registry.discover_all()
     frame_cls = registry.get_frame_by_id("gitchanges")
     if not frame_cls:
         pytest.skip("GitChangesFrame not found")
-    
+
     # Extract helper classes from the module where GitChangesFrame is defined
     # or from the git_diff_parser module directly (since we used absolute import)
-    
+
     if "git_diff_parser" in sys.modules:
         parser_module = sys.modules["git_diff_parser"]
         return {
@@ -35,7 +37,7 @@ def gitchanges_components():
             "FileDiff": getattr(parser_module, "FileDiff"),
             "DiffHunk": getattr(parser_module, "DiffHunk"),
         }
-    
+
     # Fallback to frame module if strict isolation used
     module = sys.modules[frame_cls.__module__]
     return {
@@ -401,7 +403,7 @@ class TestGitChangesFrame:
 
         # Should have summary + individual line findings
         assert len(findings) > 0
-        assert findings[0].severity == "info"
+        assert findings[0].severity == "low"
 
     def test_get_git_diff_staged_mode(self):
         """Test git diff command for staged mode."""
@@ -435,9 +437,7 @@ class TestGitChangesFrame:
 
     def test_get_git_diff_branch_mode(self):
         """Test git diff command for branch mode."""
-        frame = self.GitChangesFrame(
-            config={"compare_mode": "branch", "base_branch": "develop"}
-        )
+        frame = self.GitChangesFrame(config={"compare_mode": "branch", "base_branch": "develop"})
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = Mock(stdout="diff output")
@@ -489,7 +489,6 @@ class TestGitChangesFrameIntegration:
     @pytest.fixture(autouse=True)
     def setup(self, gitchanges_components):
         self.GitChangesFrame = gitchanges_components["GitChangesFrame"]
-
 
     @pytest.mark.asyncio
     async def test_full_workflow_with_real_diff(self):

--- a/tests/validation/frames/spec/test_spec_frame_timeout.py
+++ b/tests/validation/frames/spec/test_spec_frame_timeout.py
@@ -25,11 +25,7 @@ from warden.shared.infrastructure.resilience import OperationTimeoutError
 
 def create_code_file(path: str = "/tmp/test.py") -> CodeFile:
     """Helper to create CodeFile instances."""
-    return CodeFile(
-        path=path,
-        content="",
-        language="python"
-    )
+    return CodeFile(path=path, content="", language="python")
 
 
 class TestSpecFrameTimeout:
@@ -39,22 +35,14 @@ class TestSpecFrameTimeout:
     async def test_gap_analysis_timeout_default_config(self):
         """Test that default timeout is 120s when not configured."""
         # Create frame without timeout config
-        frame = SpecFrame(config={
-            "platforms": [
-                {
-                    "name": "consumer",
-                    "path": "/tmp/consumer",
-                    "type": "flutter",
-                    "role": "consumer"
-                },
-                {
-                    "name": "provider",
-                    "path": "/tmp/provider",
-                    "type": "spring-boot",
-                    "role": "provider"
-                }
-            ]
-        })
+        frame = SpecFrame(
+            config={
+                "platforms": [
+                    {"name": "consumer", "path": "/tmp/consumer", "type": "flutter", "role": "consumer"},
+                    {"name": "provider", "path": "/tmp/provider", "type": "spring-boot", "role": "provider"},
+                ]
+            }
+        )
 
         # Check default timeout is used
         timeout = frame.config.get("gap_analysis_timeout", 120)
@@ -64,10 +52,7 @@ class TestSpecFrameTimeout:
     async def test_gap_analysis_timeout_custom_config(self):
         """Test custom timeout configuration."""
         # Create frame with custom timeout
-        frame = SpecFrame(config={
-            "platforms": [],
-            "gap_analysis_timeout": 60
-        })
+        frame = SpecFrame(config={"platforms": [], "gap_analysis_timeout": 60})
 
         timeout = frame.config.get("gap_analysis_timeout", 120)
         assert timeout == 60
@@ -75,6 +60,7 @@ class TestSpecFrameTimeout:
     @pytest.mark.asyncio
     async def test_gap_analysis_timeout_triggers_warning(self):
         """Test that timeout creates a warning finding."""
+
         # Create a mock that simulates a slow gap analysis
         async def slow_analyze(*args, **kwargs):
             await asyncio.sleep(10)  # Simulate slow operation
@@ -83,63 +69,40 @@ class TestSpecFrameTimeout:
 
         config = {
             "platforms": [
-                {
-                    "name": "consumer",
-                    "path": "/tmp/consumer",
-                    "type": "flutter",
-                    "role": "consumer"
-                },
-                {
-                    "name": "provider",
-                    "path": "/tmp/provider",
-                    "type": "spring-boot",
-                    "role": "provider"
-                }
+                {"name": "consumer", "path": "/tmp/consumer", "type": "flutter", "role": "consumer"},
+                {"name": "provider", "path": "/tmp/provider", "type": "spring-boot", "role": "provider"},
             ],
-            "gap_analysis_timeout": 0.1  # Very short timeout for testing
+            "gap_analysis_timeout": 0.1,  # Very short timeout for testing
         }
 
         frame = SpecFrame(config=config)
 
         # Mock the _extract_contract to return valid contracts
         consumer_contract = Contract(
-            name="consumer",
-            operations=[
-                OperationDefinition(
-                    name="getUsers",
-                    operation_type=OperationType.QUERY
-                )
-            ]
+            name="consumer", operations=[OperationDefinition(name="getUsers", operation_type=OperationType.QUERY)]
         )
         provider_contract = Contract(
-            name="provider",
-            operations=[
-                OperationDefinition(
-                    name="getUsers",
-                    operation_type=OperationType.QUERY
-                )
-            ]
+            name="provider", operations=[OperationDefinition(name="getUsers", operation_type=OperationType.QUERY)]
         )
 
         # Mock validation to pass
-        with patch.object(frame, '_validate_configuration', return_value=None):
-            with patch.object(frame, '_extract_contract') as mock_extract:
+        with patch.object(frame, "_validate_configuration", return_value=None):
+            with patch.object(frame, "_extract_contract") as mock_extract:
                 # Return contracts for both platforms
                 mock_extract.side_effect = [consumer_contract, provider_contract]
 
                 # Mock _analyze_gaps to be slow
-                with patch.object(frame, '_analyze_gaps', side_effect=slow_analyze):
+                with patch.object(frame, "_analyze_gaps", side_effect=slow_analyze):
                     # Execute frame
                     code_file = create_code_file()
                     result = await frame.execute(code_file)
 
                     # Should have warning finding about timeout
                     timeout_findings = [
-                        f for f in result.findings
-                        if "timeout" in f.id.lower() or "timeout" in f.message.lower()
+                        f for f in result.findings if "timeout" in f.id.lower() or "timeout" in f.message.lower()
                     ]
                     assert len(timeout_findings) > 0
-                    assert any(f.severity == "warning" for f in timeout_findings)
+                    assert any(f.severity == "medium" for f in timeout_findings)
 
                     # Check metadata
                     assert result.metadata.get("timeout_occurred") is True
@@ -148,26 +111,17 @@ class TestSpecFrameTimeout:
     @pytest.mark.asyncio
     async def test_gap_analysis_continues_on_timeout(self):
         """Test that frame continues gracefully after timeout."""
+
         # Simulate timeout by raising OperationTimeoutError
         async def timeout_analyze(*args, **kwargs):
             raise OperationTimeoutError("gap_analysis", 120)
 
         config = {
             "platforms": [
-                {
-                    "name": "consumer",
-                    "path": "/tmp/consumer",
-                    "type": "flutter",
-                    "role": "consumer"
-                },
-                {
-                    "name": "provider",
-                    "path": "/tmp/provider",
-                    "type": "spring-boot",
-                    "role": "provider"
-                }
+                {"name": "consumer", "path": "/tmp/consumer", "type": "flutter", "role": "consumer"},
+                {"name": "provider", "path": "/tmp/provider", "type": "spring-boot", "role": "provider"},
             ],
-            "gap_analysis_timeout": 120
+            "gap_analysis_timeout": 120,
         }
 
         frame = SpecFrame(config=config)
@@ -177,11 +131,11 @@ class TestSpecFrameTimeout:
         provider_contract = Contract(name="provider")
 
         # Mock validation to pass (skip path checks)
-        with patch.object(frame, '_validate_configuration', return_value=None):
-            with patch.object(frame, '_extract_contract') as mock_extract:
+        with patch.object(frame, "_validate_configuration", return_value=None):
+            with patch.object(frame, "_extract_contract") as mock_extract:
                 mock_extract.side_effect = [consumer_contract, provider_contract]
 
-                with patch.object(frame, '_analyze_gaps', side_effect=timeout_analyze):
+                with patch.object(frame, "_analyze_gaps", side_effect=timeout_analyze):
                     code_file = create_code_file()
                     result = await frame.execute(code_file)
 
@@ -199,25 +153,16 @@ class TestSpecFrameTimeout:
     @pytest.mark.asyncio
     async def test_gap_analysis_metadata_tracking(self):
         """Test that timeout metadata is properly tracked."""
+
         async def timeout_analyze(*args, **kwargs):
             raise OperationTimeoutError("gap_analysis", 45)
 
         config = {
             "platforms": [
-                {
-                    "name": "mobile",
-                    "path": "/tmp/mobile",
-                    "type": "flutter",
-                    "role": "consumer"
-                },
-                {
-                    "name": "backend",
-                    "path": "/tmp/backend",
-                    "type": "spring-boot",
-                    "role": "provider"
-                }
+                {"name": "mobile", "path": "/tmp/mobile", "type": "flutter", "role": "consumer"},
+                {"name": "backend", "path": "/tmp/backend", "type": "spring-boot", "role": "provider"},
             ],
-            "gap_analysis_timeout": 45
+            "gap_analysis_timeout": 45,
         }
 
         frame = SpecFrame(config=config)
@@ -226,11 +171,11 @@ class TestSpecFrameTimeout:
         provider_contract = Contract(name="backend")
 
         # Mock validation to pass
-        with patch.object(frame, '_validate_configuration', return_value=None):
-            with patch.object(frame, '_extract_contract') as mock_extract:
+        with patch.object(frame, "_validate_configuration", return_value=None):
+            with patch.object(frame, "_extract_contract") as mock_extract:
                 mock_extract.side_effect = [consumer_contract, provider_contract]
 
-                with patch.object(frame, '_analyze_gaps', side_effect=timeout_analyze):
+                with patch.object(frame, "_analyze_gaps", side_effect=timeout_analyze):
                     code_file = create_code_file()
                     result = await frame.execute(code_file)
 
@@ -242,30 +187,19 @@ class TestSpecFrameTimeout:
     @pytest.mark.asyncio
     async def test_gap_analysis_no_timeout_on_success(self):
         """Test that successful analysis doesn't set timeout metadata."""
+
         async def fast_analyze(*args, **kwargs):
             # Return empty result quickly
             from warden.validation.frames.spec.models import SpecAnalysisResult
-            return SpecAnalysisResult(
-                consumer_contract=args[0],
-                provider_contract=args[1]
-            )
+
+            return SpecAnalysisResult(consumer_contract=args[0], provider_contract=args[1])
 
         config = {
             "platforms": [
-                {
-                    "name": "consumer",
-                    "path": "/tmp/consumer",
-                    "type": "flutter",
-                    "role": "consumer"
-                },
-                {
-                    "name": "provider",
-                    "path": "/tmp/provider",
-                    "type": "spring-boot",
-                    "role": "provider"
-                }
+                {"name": "consumer", "path": "/tmp/consumer", "type": "flutter", "role": "consumer"},
+                {"name": "provider", "path": "/tmp/provider", "type": "spring-boot", "role": "provider"},
             ],
-            "gap_analysis_timeout": 120
+            "gap_analysis_timeout": 120,
         }
 
         frame = SpecFrame(config=config)
@@ -274,11 +208,11 @@ class TestSpecFrameTimeout:
         provider_contract = Contract(name="provider")
 
         # Mock validation to pass
-        with patch.object(frame, '_validate_configuration', return_value=None):
-            with patch.object(frame, '_extract_contract') as mock_extract:
+        with patch.object(frame, "_validate_configuration", return_value=None):
+            with patch.object(frame, "_extract_contract") as mock_extract:
                 mock_extract.side_effect = [consumer_contract, provider_contract]
 
-                with patch.object(frame, '_analyze_gaps', side_effect=fast_analyze):
+                with patch.object(frame, "_analyze_gaps", side_effect=fast_analyze):
                     code_file = create_code_file()
                     result = await frame.execute(code_file)
 


### PR DESCRIPTION
Fixes #352

## Changes
- `gitchanges_frame.py:304,316`: `severity="info"` → `"low"`
- `spec_frame.py:479`: `severity="warning"` → `"medium"`
- Updated corresponding test assertions to match corrected values

## Why
`Finding.severity` only accepts `critical`, `high`, `medium`, `low`. Using `"info"`/`"warning"` was silently accepted by Pydantic but broke Panel rendering and severity filtering.