### PR TITLE
fix(fortification): restore missing FortificationResult fields — orchestrator AttributeError (#354)

### DIFF
--- a/src/warden/fortification/application/fortifiers/error_handling.py
+++ b/src/warden/fortification/application/fortifiers/error_handling.py
@@ -5,6 +5,7 @@ Adds try-except blocks, error handling, and validation to code.
 Detects risky operations (async, file I/O, network, database) and wraps them.
 """
 
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -97,8 +98,6 @@ class ErrorHandlingFortifier(BaseFortifier):
             )
             return FortificationResult(
                 success=True,
-                file_path=code_file.path,
-                issues_found=0,
                 suggestions=[],
                 summary="No error handling issues found",
                 fortifier_name=self.name,
@@ -113,12 +112,13 @@ class ErrorHandlingFortifier(BaseFortifier):
         # Create basic suggestions from static analysis
         fortification_suggestions = [
             Fortification(
-                issue_line=s.line_number,
-                issue_type=s.type,
-                description=s.description,
-                suggestion=f"Wrap this {s.type} in a try-except block to handle potential errors",
-                severity=s.severity,
-                code_snippet=self._get_code_snippet(code_file.content, s.line_number),
+                id=str(uuid.uuid4()),
+                title=f"{s.type}: {s.description}",
+                detail=f"Wrap this {s.type} in a try-except block to handle potential errors",
+                line_number=s.line_number,
+                severity=s.severity.lower(),
+                suggested_code=self._get_code_snippet(code_file.content, s.line_number),
+                file_path=code_file.path,
             )
             for s in suggestions
         ]
@@ -145,8 +145,6 @@ class ErrorHandlingFortifier(BaseFortifier):
 
         return FortificationResult(
             success=True,
-            file_path=code_file.path,
-            issues_found=len(suggestions),
             suggestions=fortification_suggestions,
             summary=f"Found {len(suggestions)} error handling issues",
             fortifier_name=self.name,
@@ -303,7 +301,7 @@ class ErrorHandlingFortifier(BaseFortifier):
             return suggestions
 
         # Build prompt for LLM (asking for suggestions, not code!)
-        issues_list = "\n".join(f"- Line {s.issue_line}: {s.description}" for s in suggestions)
+        issues_list = "\n".join(f"- Line {s.line_number}: {s.detail}" for s in suggestions)
 
         prompt = f"""You are a code safety expert. For each issue below, provide a specific suggestion on how to fix it.
 
@@ -338,15 +336,16 @@ Format: JSON array of objects with keys: issueLine (int), suggestion (string)"""
 
             enhanced = []
             for sug in suggestions:
-                llm_text = llm_map.get(sug.issue_line, sug.suggestion)
+                llm_text = llm_map.get(sug.line_number, sug.detail)
                 enhanced.append(
                     Fortification(
-                        issue_line=sug.issue_line,
-                        issue_type=sug.issue_type,
-                        description=sug.description,
-                        suggestion=llm_text,  # Enhanced by LLM
+                        id=sug.id,
+                        title=sug.title,
+                        detail=llm_text,  # Enhanced by LLM
+                        line_number=sug.line_number,
                         severity=sug.severity,
-                        code_snippet=sug.code_snippet,
+                        suggested_code=sug.suggested_code,
+                        file_path=sug.file_path,
                     )
                 )
 

--- a/src/warden/fortification/domain/models.py
+++ b/src/warden/fortification/domain/models.py
@@ -95,6 +95,11 @@ class FortificationResult(BaseDomainModel):
     summary: str = ""
     duration: float = 0.0
     timestamp: datetime = Field(default_factory=datetime.now)
+    # Code-modification fields used by the fortification orchestrator chain
+    original_code: str = ""
+    fortified_code: str = ""
+    error_message: str = ""
+    fortifier_name: str = ""
 
     def to_json(self) -> dict[str, Any]:
         """Serialize to Panel-compatible JSON."""


### PR DESCRIPTION
Fixes #354

## Root Cause
`FortificationResult` model was refactored to remove `fortified_code`, `original_code`, `error_message`, `fortifier_name` fields, but the orchestrator and all 4 fortifiers still referenced them. The orchestrator's `result.fortified_code` access caused **AttributeError** at runtime, breaking the entire fortification chain.

Additionally `error_handling.py` was creating `Fortification(issue_line=, issue_type=, description=, suggestion=)` — all wrong field names causing **TypeError**.

## Changes
- `models.py`: Restore `fortified_code`, `original_code`, `error_message`, `fortifier_name` fields to `FortificationResult`
- `error_handling.py`: Add `import uuid`; fix `Fortification()` constructor to use correct fields (`id`, `title`, `detail`, `line_number`, `severity`, `suggested_code`, `file_path`); fix `_enhance_suggestions_with_llm_async` field access; remove invalid `file_path`/`issues_found` from early-return `FortificationResult` calls

## Note
`test_fortification_panel_compat.py::test_fortification_to_json` is a pre-existing failure on `dev` (verified via git stash). Not introduced by this fix.