### PR TITLE
fix(llm): add missing max_tokens param to OpenAI and Offline complete_async (#356)

### DIFF
--- a/src/warden/llm/providers/offline.py
+++ b/src/warden/llm/providers/offline.py
@@ -36,7 +36,12 @@ class OfflineClient(ILlmClient):
         return True
 
     async def complete_async(
-        self, prompt: str, system_prompt: str = "", model: str | None = None, use_fast_tier: bool = False
+        self,
+        prompt: str,
+        system_prompt: str = "",
+        model: str | None = None,
+        use_fast_tier: bool = False,
+        max_tokens: int = 2000,
     ) -> LlmResponse:
         # Satisfy the LlmRequest type contract instead of passing None (#210)
         return await self.send_async(LlmRequest(system_prompt=system_prompt, user_message=prompt))

--- a/src/warden/llm/providers/openai.py
+++ b/src/warden/llm/providers/openai.py
@@ -314,7 +314,12 @@ class OpenAIClient(ILlmClient):
             return False
 
     async def complete_async(
-        self, prompt: str, system_prompt: str = "You are a helpful coding assistant.", model: str | None = None
+        self,
+        prompt: str,
+        system_prompt: str = "You are a helpful coding assistant.",
+        model: str | None = None,
+        use_fast_tier: bool = False,
+        max_tokens: int = 2000,
     ) -> LlmResponse:
         """
         Simple completion method for non-streaming requests.
@@ -323,6 +328,8 @@ class OpenAIClient(ILlmClient):
             prompt: User prompt
             system_prompt: System prompt (optional)
             model: Model name override (optional)
+            use_fast_tier: Ignored for OpenAI (always smart tier)
+            max_tokens: Maximum tokens to generate
 
         Returns:
             LlmResponse object with content and token usage
@@ -335,7 +342,7 @@ class OpenAIClient(ILlmClient):
             system_prompt=system_prompt,
             model=model or self._default_model,
             temperature=0.0,  # Idempotency
-            max_tokens=2000,
+            max_tokens=max_tokens,
             timeout_seconds=30.0,
         )
 


### PR DESCRIPTION
Fixes #356

## Changes
- `openai.py`: Add `use_fast_tier: bool = False` and `max_tokens: int = 2000` to `complete_async()`; pass `max_tokens` through to `LlmRequest` (previously hardcoded 2000)
- `offline.py`: Add `max_tokens: int = 2000` to `complete_async()` signature to match `ILlmClient` contract

Both overrides now match the base class signature: `(prompt, system_prompt, model, use_fast_tier, max_tokens)`.