### PR TITLE
fix(pipeline): use None-check for TaintAware injection to avoid skipping empty taint dict (#360)

### DIFF
--- a/src/warden/pipeline/application/orchestrator/frame_runner.py
+++ b/src/warden/pipeline/application/orchestrator/frame_runner.py
@@ -409,7 +409,7 @@ class FrameRunner:
 
         # Inject taint paths into TaintAware frames
         if isinstance(frame, TaintAware):
-            if hasattr(context, "taint_paths") and context.taint_paths:
+            if hasattr(context, "taint_paths") and context.taint_paths is not None:
                 try:
                     frame.set_taint_paths(context.taint_paths)
                     logger.debug(


### PR DESCRIPTION
Fixes #360

## Change
`frame_runner.py:412`: `context.taint_paths` (truthiness) → `context.taint_paths is not None`

## Why
When `TaintAnalysisService` completes but finds no paths, `context.taint_paths = {}`. The truthiness check `if context.taint_paths:` evaluated `{}` as falsy → `set_taint_paths()` was never called → SecurityFrame/ResilienceFrame fell back to inline re-analysis, duplicating work and losing cross-file context.

Now consistent with `DataFlowAware` injection which correctly uses `is not None` (line 429).