### PR TITLE
feat(report): add detection_source field to Finding for LLM vs deterministic attribution

### DIFF
--- a/src/warden/pipeline/application/orchestrator/findings_cache.py
+++ b/src/warden/pipeline/application/orchestrator/findings_cache.py
@@ -227,6 +227,7 @@ def _serialize_finding(f: Finding) -> dict[str, Any]:
         "line": f.line,
         "column": f.column,
         "is_blocker": f.is_blocker,
+        "detection_source": f.detection_source,
     }
 
 
@@ -246,4 +247,5 @@ def _deserialize_finding(d: dict[str, Any]) -> Finding:
         line=int(d.get("line", 0)),
         column=int(d.get("column", 0)),
         is_blocker=bool(d.get("is_blocker", False)),
+        detection_source=d.get("detection_source"),
     )

--- a/src/warden/pipeline/application/orchestrator/rust_pre_filter.py
+++ b/src/warden/pipeline/application/orchestrator/rust_pre_filter.py
@@ -78,6 +78,10 @@ class RustPreFilter:
                 if filtered_findings:
                     logger.info("rust_pre_filtering_found_issues", raw=total_hits, filtered=len(filtered_findings))
 
+                    # Tag all rust-engine findings with their detection source
+                    for finding in filtered_findings:
+                        finding.detection_source = "rust_engine"
+
                     frame_id = "system_security_rules"
                     frame_result = FrameResult(
                         frame_id=frame_id,

--- a/src/warden/pipeline/domain/models.py
+++ b/src/warden/pipeline/domain/models.py
@@ -304,6 +304,19 @@ class PipelineResult(BaseDomainModel):
         # Blocker violations count (custom rules with is_blocker: true)
         data["blocker_violations"] = self.blocker_violations
 
+        # Detection source attribution counts (LLM vs deterministic)
+        all_findings = [f for fr in self.frame_results for f in fr.findings]
+        data["llmFindingCount"] = sum(
+            1
+            for f in all_findings
+            if f.detection_source is not None and f.detection_source.startswith("llm")
+        )
+        data["deterministicFindingCount"] = sum(
+            1
+            for f in all_findings
+            if f.detection_source is None or not f.detection_source.startswith("llm")
+        )
+
         # Add token usage
         data["llmUsage"] = {
             "totalTokens": self.total_tokens,

--- a/src/warden/reports/generator.py
+++ b/src/warden/reports/generator.py
@@ -475,6 +475,13 @@ class ReportGenerator:
                         result["properties"] = {}
                     result["properties"]["exploitEvidence"] = exploit_evidence
 
+                # Add detection source attribution if present (#371)
+                detection_source = self._get_val(finding, "detectionSource", None)
+                if detection_source:
+                    if "properties" not in result:
+                        result["properties"] = {}
+                    result["properties"]["detectionSource"] = detection_source
+
                 # Add SARIF fixes array when remediation is populated (#197)
                 remediation = self._get_val(finding, "remediation", None)
                 if remediation:

--- a/src/warden/validation/domain/frame.py
+++ b/src/warden/validation/domain/frame.py
@@ -144,6 +144,10 @@ class Finding:
     remediation: Remediation | None = None  # Suggested fix
     machine_context: MachineContext | None = None  # Structured vulnerability context
     exploit_evidence: ExploitEvidence | None = None  # Witness payload evidence
+    # Attribution: identifies which analysis engine produced this finding.
+    # Valid values: "rust_engine", "regex", "ast", "taint", "llm", "llm_verified"
+    # None means source is unknown or not yet attributed.
+    detection_source: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         """Serialize to Panel JSON."""
@@ -163,6 +167,8 @@ class Finding:
             result["machineContext"] = self.machine_context.to_json()
         if self.exploit_evidence:
             result["exploitEvidence"] = self.exploit_evidence.to_json()
+        if self.detection_source is not None:
+            result["detectionSource"] = self.detection_source
         return result
 
     def to_dict(self) -> dict[str, Any]:
@@ -209,6 +215,24 @@ class FrameResult:
     def passed(self) -> bool:
         """Check if frame passed (no issues)."""
         return self.status == "passed"
+
+    @property
+    def llm_finding_count(self) -> int:
+        """Count findings attributed to LLM-based analysis."""
+        return sum(
+            1
+            for f in self.findings
+            if f.detection_source is not None and f.detection_source.startswith("llm")
+        )
+
+    @property
+    def deterministic_finding_count(self) -> int:
+        """Count findings attributed to deterministic (non-LLM) analysis."""
+        return sum(
+            1
+            for f in self.findings
+            if f.detection_source is None or not f.detection_source.startswith("llm")
+        )
 
     def to_json(self) -> dict[str, Any]:
         """Serialize to Panel JSON (camelCase)."""

--- a/src/warden/validation/frames/security/frame.py
+++ b/src/warden/validation/frames/security/frame.py
@@ -914,6 +914,16 @@ class SecurityFrame(ValidationFrame, BatchExecutable, TaintAware, CodeGraphAware
 
         for check_result in check_results:
             for check_finding in check_result.findings:
+                # Determine detection source from check_id
+                check_id = check_finding.check_id
+                if check_id == "llm-security":
+                    detection_source: str | None = "llm"
+                elif check_id == "taint-analysis":
+                    detection_source = "taint"
+                else:
+                    # Built-in pattern/regex checks (sql-injection, xss, secrets, etc.)
+                    detection_source = "regex"
+
                 # Convert CheckFinding to Frame-level Finding
                 finding = Finding(
                     id=f"{self.frame_id}-{check_finding.check_id}-{len(findings)}",
@@ -923,6 +933,7 @@ class SecurityFrame(ValidationFrame, BatchExecutable, TaintAware, CodeGraphAware
                     detail=check_finding.suggestion,
                     code=check_finding.code_snippet,
                     is_blocker=check_finding.is_blocker,
+                    detection_source=detection_source,
                 )
 
                 # Populate explicitly tagged LLM context instances on creation

--- a/tests/validation/domain/test_detection_source.py
+++ b/tests/validation/domain/test_detection_source.py
@@ -1,0 +1,329 @@
+"""Tests for detection_source field on Finding and related attribution logic.
+
+Covers:
+- TestFindingDetectionSource: field default, valid values, to_json serialization
+- TestFrameResultCounts: llm_finding_count and deterministic_finding_count properties
+- TestFindingsCacheDetectionSource: serialize/deserialize roundtrip for detection_source
+- TestPipelineResultCounts: llmFindingCount and deterministicFindingCount in to_json
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from warden.pipeline.application.orchestrator.findings_cache import (
+    _deserialize_finding,
+    _serialize_finding,
+)
+from warden.validation.domain.frame import Finding, FrameResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_finding(
+    id: str = "F001",
+    severity: str = "high",
+    message: str = "test message",
+    location: str = "src/app.py:10",
+    detection_source: str | None = None,
+) -> Finding:
+    return Finding(
+        id=id,
+        severity=severity,
+        message=message,
+        location=location,
+        detection_source=detection_source,
+    )
+
+
+def _make_frame_result(findings: list[Finding]) -> FrameResult:
+    return FrameResult(
+        frame_id="security",
+        frame_name="Security Analysis",
+        status="failed" if findings else "passed",
+        duration=0.1,
+        issues_found=len(findings),
+        is_blocker=False,
+        findings=findings,
+    )
+
+
+# ===========================================================================
+# TestFindingDetectionSource
+# ===========================================================================
+
+
+class TestFindingDetectionSource:
+    """Field presence, default value, and JSON serialization."""
+
+    def test_default_is_none(self) -> None:
+        f = _make_finding()
+        assert f.detection_source is None
+
+    def test_set_rust_engine(self) -> None:
+        f = _make_finding(detection_source="rust_engine")
+        assert f.detection_source == "rust_engine"
+
+    def test_set_regex(self) -> None:
+        f = _make_finding(detection_source="regex")
+        assert f.detection_source == "regex"
+
+    def test_set_ast(self) -> None:
+        f = _make_finding(detection_source="ast")
+        assert f.detection_source == "ast"
+
+    def test_set_taint(self) -> None:
+        f = _make_finding(detection_source="taint")
+        assert f.detection_source == "taint"
+
+    def test_set_llm(self) -> None:
+        f = _make_finding(detection_source="llm")
+        assert f.detection_source == "llm"
+
+    def test_set_llm_verified(self) -> None:
+        f = _make_finding(detection_source="llm_verified")
+        assert f.detection_source == "llm_verified"
+
+    def test_to_json_omits_key_when_none(self) -> None:
+        """When detection_source is None, detectionSource must not appear in JSON."""
+        f = _make_finding()
+        data = f.to_json()
+        assert "detectionSource" not in data
+
+    def test_to_json_includes_key_when_set(self) -> None:
+        f = _make_finding(detection_source="llm")
+        data = f.to_json()
+        assert data["detectionSource"] == "llm"
+
+    def test_to_json_rust_engine(self) -> None:
+        f = _make_finding(detection_source="rust_engine")
+        data = f.to_json()
+        assert data["detectionSource"] == "rust_engine"
+
+    def test_to_json_regex(self) -> None:
+        f = _make_finding(detection_source="regex")
+        data = f.to_json()
+        assert data["detectionSource"] == "regex"
+
+
+# ===========================================================================
+# TestFrameResultCounts
+# ===========================================================================
+
+
+class TestFrameResultCounts:
+    """llm_finding_count and deterministic_finding_count computed properties."""
+
+    def test_no_findings_both_counts_zero(self) -> None:
+        fr = _make_frame_result([])
+        assert fr.llm_finding_count == 0
+        assert fr.deterministic_finding_count == 0
+
+    def test_all_none_source_are_deterministic(self) -> None:
+        findings = [_make_finding(id=f"F{i}") for i in range(3)]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count == 0
+        assert fr.deterministic_finding_count == 3
+
+    def test_all_regex_are_deterministic(self) -> None:
+        findings = [_make_finding(id=f"F{i}", detection_source="regex") for i in range(4)]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count == 0
+        assert fr.deterministic_finding_count == 4
+
+    def test_llm_source_counted_as_llm(self) -> None:
+        findings = [_make_finding(id="F1", detection_source="llm")]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count == 1
+        assert fr.deterministic_finding_count == 0
+
+    def test_llm_verified_source_counted_as_llm(self) -> None:
+        findings = [_make_finding(id="F1", detection_source="llm_verified")]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count == 1
+        assert fr.deterministic_finding_count == 0
+
+    def test_mixed_sources_counted_correctly(self) -> None:
+        findings = [
+            _make_finding(id="F1", detection_source="regex"),
+            _make_finding(id="F2", detection_source="llm"),
+            _make_finding(id="F3", detection_source="taint"),
+            _make_finding(id="F4", detection_source="llm_verified"),
+            _make_finding(id="F5"),  # None
+            _make_finding(id="F6", detection_source="rust_engine"),
+        ]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count == 2  # llm + llm_verified
+        assert fr.deterministic_finding_count == 4  # regex + taint + None + rust_engine
+
+    def test_counts_sum_to_total_findings(self) -> None:
+        findings = [
+            _make_finding(id="F1", detection_source="llm"),
+            _make_finding(id="F2", detection_source="regex"),
+            _make_finding(id="F3"),
+        ]
+        fr = _make_frame_result(findings)
+        assert fr.llm_finding_count + fr.deterministic_finding_count == len(findings)
+
+    def test_rust_engine_is_deterministic(self) -> None:
+        findings = [_make_finding(id="F1", detection_source="rust_engine")]
+        fr = _make_frame_result(findings)
+        assert fr.deterministic_finding_count == 1
+        assert fr.llm_finding_count == 0
+
+    def test_taint_is_deterministic(self) -> None:
+        findings = [_make_finding(id="F1", detection_source="taint")]
+        fr = _make_frame_result(findings)
+        assert fr.deterministic_finding_count == 1
+        assert fr.llm_finding_count == 0
+
+    def test_ast_is_deterministic(self) -> None:
+        findings = [_make_finding(id="F1", detection_source="ast")]
+        fr = _make_frame_result(findings)
+        assert fr.deterministic_finding_count == 1
+        assert fr.llm_finding_count == 0
+
+
+# ===========================================================================
+# TestFindingsCacheDetectionSource
+# ===========================================================================
+
+
+class TestFindingsCacheDetectionSource:
+    """detection_source survives serialize -> deserialize roundtrip."""
+
+    def test_roundtrip_llm_source(self) -> None:
+        f = _make_finding(detection_source="llm")
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source == "llm"
+
+    def test_roundtrip_regex_source(self) -> None:
+        f = _make_finding(detection_source="regex")
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source == "regex"
+
+    def test_roundtrip_rust_engine_source(self) -> None:
+        f = _make_finding(detection_source="rust_engine")
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source == "rust_engine"
+
+    def test_roundtrip_none_source(self) -> None:
+        f = _make_finding(detection_source=None)
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source is None
+
+    def test_roundtrip_taint_source(self) -> None:
+        f = _make_finding(detection_source="taint")
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source == "taint"
+
+    def test_roundtrip_llm_verified_source(self) -> None:
+        f = _make_finding(detection_source="llm_verified")
+        d = _serialize_finding(f)
+        restored = _deserialize_finding(d)
+        assert restored.detection_source == "llm_verified"
+
+    def test_serialize_includes_detection_source_key(self) -> None:
+        f = _make_finding(detection_source="ast")
+        d = _serialize_finding(f)
+        assert "detection_source" in d
+        assert d["detection_source"] == "ast"
+
+    def test_serialize_none_persists_as_none(self) -> None:
+        f = _make_finding(detection_source=None)
+        d = _serialize_finding(f)
+        assert "detection_source" in d
+        assert d["detection_source"] is None
+
+    def test_deserialize_missing_key_defaults_to_none(self) -> None:
+        """Old cache entries without detection_source key deserialize gracefully."""
+        d = _serialize_finding(_make_finding())
+        del d["detection_source"]
+        restored = _deserialize_finding(d)
+        assert restored.detection_source is None
+
+
+# ===========================================================================
+# TestPipelineResultCounts
+# ===========================================================================
+
+
+class TestPipelineResultCounts:
+    """PipelineResult.to_json includes llmFindingCount and deterministicFindingCount."""
+
+    def _make_pipeline_result(self, frame_results: list[FrameResult]) -> Any:
+        from datetime import datetime, timezone
+
+        from warden.pipeline.domain.enums import PipelineStatus
+        from warden.pipeline.domain.models import PipelineResult
+
+        return PipelineResult(
+            pipeline_id="test-pipeline",
+            pipeline_name="Test Pipeline",
+            status=PipelineStatus.COMPLETED,
+            duration=1.0,
+            total_frames=len(frame_results),
+            frames_passed=len(frame_results),
+            frames_failed=0,
+            frames_skipped=0,
+            total_findings=sum(fr.issues_found for fr in frame_results),
+            critical_findings=0,
+            high_findings=0,
+            medium_findings=0,
+            low_findings=0,
+            frame_results=frame_results,
+        )
+
+    def test_empty_pipeline_both_counts_zero(self) -> None:
+        pr = self._make_pipeline_result([])
+        data = pr.to_json()
+        assert data["llmFindingCount"] == 0
+        assert data["deterministicFindingCount"] == 0
+
+    def test_llm_findings_counted_across_frames(self) -> None:
+        frame1 = _make_frame_result([
+            _make_finding(id="F1", detection_source="llm"),
+            _make_finding(id="F2", detection_source="regex"),
+        ])
+        frame2 = _make_frame_result([
+            _make_finding(id="F3", detection_source="llm_verified"),
+        ])
+        pr = self._make_pipeline_result([frame1, frame2])
+        data = pr.to_json()
+        assert data["llmFindingCount"] == 2
+        assert data["deterministicFindingCount"] == 1
+
+    def test_all_deterministic(self) -> None:
+        frame1 = _make_frame_result([
+            _make_finding(id="F1", detection_source="rust_engine"),
+            _make_finding(id="F2", detection_source="taint"),
+            _make_finding(id="F3"),
+        ])
+        pr = self._make_pipeline_result([frame1])
+        data = pr.to_json()
+        assert data["llmFindingCount"] == 0
+        assert data["deterministicFindingCount"] == 3
+
+    def test_counts_sum_to_total_across_all_frames(self) -> None:
+        frame1 = _make_frame_result([
+            _make_finding(id="F1", detection_source="llm"),
+            _make_finding(id="F2", detection_source="regex"),
+        ])
+        frame2 = _make_frame_result([
+            _make_finding(id="F3", detection_source="rust_engine"),
+            _make_finding(id="F4", detection_source="llm_verified"),
+        ])
+        pr = self._make_pipeline_result([frame1, frame2])
+        data = pr.to_json()
+        total = data["llmFindingCount"] + data["deterministicFindingCount"]
+        assert total == 4


### PR DESCRIPTION
## Summary
- `Finding.detection_source` field: `"rust_engine"`, `"regex"`, `"ast"`, `"taint"`, `"llm"`, `"llm_verified"` or `None`
- `FrameResult.llm_finding_count` / `deterministic_finding_count` computed properties
- `PipelineResult.to_json()` outputs `llmFindingCount` and `deterministicFindingCount`
- SARIF results include `properties.detectionSource`
- FindingsCache serializes/deserializes `detection_source` (backward compatible)
- Security frame tags findings by source: llm, taint, or regex
- Rust engine tags all findings as `rust_engine`

Closes #371

## Test plan
- [x] 34 new tests covering all attribution paths
- [x] Backward compatibility with old cache entries (None default)
- [x] Existing test suite passes (69/69)