### PR TITLE
fix: resolve 3 stale test failures and 3 error handling gaps (#402)

### DIFF
--- a/src/warden/build_context/parsers/package_json_parser.py
+++ b/src/warden/build_context/parsers/package_json_parser.py
@@ -8,6 +8,10 @@ import json
 from pathlib import Path
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 from warden.build_context.models import (
     BuildContext,
     BuildScript,
@@ -131,7 +135,7 @@ class PackageJsonParser:
 
         except (OSError, json.JSONDecodeError) as e:
             # Log error but don't crash - return None
-            print(f"Error parsing package.json: {e}")
+            logger.warning("package_json_parse_error", error=str(e))
             return None
 
     def _parse_dependencies(self, deps_dict: dict[str, str], dep_type: DependencyType) -> list[Dependency]:

--- a/src/warden/build_context/parsers/pyproject_parser.py
+++ b/src/warden/build_context/parsers/pyproject_parser.py
@@ -8,6 +8,10 @@ import re
 from pathlib import Path
 from typing import Any
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 from warden.build_context.models import (
     BuildContext,
     BuildScript,
@@ -93,7 +97,7 @@ class PyprojectParser:
                 return None
 
         except (OSError, ValueError) as e:
-            print(f"Error parsing pyproject.toml: {e}")
+            logger.warning("pyproject_toml_parse_error", error=str(e))
             return None
 
     def _parse_poetry(self, data: dict[str, Any], build_system: BuildSystem) -> BuildContext:

--- a/src/warden/build_context/parsers/requirements_parser.py
+++ b/src/warden/build_context/parsers/requirements_parser.py
@@ -7,6 +7,10 @@ Extracts dependencies from requirements.txt and related files.
 import re
 from pathlib import Path
 
+import structlog
+
+logger = structlog.get_logger(__name__)
+
 from warden.build_context.models import (
     BuildContext,
     BuildSystem,
@@ -90,7 +94,7 @@ class RequirementsParser:
             )
 
         except OSError as e:
-            print(f"Error parsing requirements.txt: {e}")
+            logger.warning("requirements_txt_parse_error", error=str(e))
             return None
 
     def _parse_requirements_file(self, file_path: Path, visited: set[Path]) -> list[Dependency]:

--- a/src/warden/cli/commands/scan_output.py
+++ b/src/warden/cli/commands/scan_output.py
@@ -308,7 +308,7 @@ def _render_text_report(
                 file_path = parts[0] if parts else location
                 try:
                     line_num = int(parts[1]) if len(parts) > 1 else 0
-                except:
+                except (ValueError, IndexError):
                     line_num = 0
 
             ext = file_path.rsplit(".", 1)[-1].lower() if "." in file_path else "py"

--- a/src/warden/pipeline/application/orchestrator/frame_runner.py
+++ b/src/warden/pipeline/application/orchestrator/frame_runner.py
@@ -674,8 +674,8 @@ class FrameRunner:
                                     frame.frame_id,
                                     findings_dicts,
                                 )
-                            except Exception:
-                                pass  # best-effort persistence
+                            except Exception as exc:
+                                logger.debug("partial_write_failed", file=str(c_file.path), error=str(exc))
 
                         return result
                     except (asyncio.TimeoutError, TimeoutError):

--- a/tests/integration/test_context_propagation.py
+++ b/tests/integration/test_context_propagation.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from pathlib import Path
 
 from warden.pipeline.domain.pipeline_context import PipelineContext
@@ -17,8 +17,9 @@ async def test_classification_phase_propagates_context_to_llm():
     """
     # 1. Setup Mock LLM
     mock_llm = AsyncMock()
-    mock_llm.send_async.return_value.success = True
-    mock_llm.send_async.return_value.content = """
+    mock_response = MagicMock()
+    mock_response.success = True
+    mock_response.content = """
     ```json
     {
         "selected_frames": ["security", "resilience"],
@@ -28,6 +29,7 @@ async def test_classification_phase_propagates_context_to_llm():
     }
     ```
     """
+    mock_llm.complete_async.return_value = mock_response
 
     # 2. Setup Pipeline Context with specific architectural data
     project_root = Path("/tmp/test_project")
@@ -47,13 +49,17 @@ async def test_classification_phase_propagates_context_to_llm():
     context.file_contexts = {"main.py": {"context": "PRODUCTION", "summary": "Main entry point"}}
     context.quality_score_before = 8.5
 
-    # 3. Initialize Executor
+    # 3. Initialize Executor with mock frames (empty list prevents LLM call)
+    mock_frame_security = MagicMock(frame_id="security", name="Security Analysis", description="Security checks")
+    mock_frame_resilience = MagicMock(frame_id="resilience", name="Resilience Analysis", description="Resilience checks")
+    mock_frames = [mock_frame_security, mock_frame_resilience]
+
     executor = ClassificationExecutor(
-        config=PipelineConfig(enable_classification=True),
+        config=PipelineConfig(enable_classification=True, force_scan=True),
         project_root=project_root,
         llm_service=mock_llm,
-        frames=[],
-        available_frames=[],
+        frames=mock_frames,
+        available_frames=mock_frames,
     )
 
     # 4. Execute Phase
@@ -64,15 +70,20 @@ async def test_classification_phase_propagates_context_to_llm():
     # But since we modified the Executor to pass context, we can just run it
     # and check the calls to mock_llm.
 
-    await executor.execute_async(context, code_files)
+    with patch(
+        "warden.pipeline.application.executors.classification_cache.ClassificationCache.get",
+        return_value=None,
+    ):
+        await executor.execute_async(context, code_files)
 
     # 5. Verify LLM Interaction
     # The LLM should have been called with a prompt containing our context
-    assert mock_llm.send_async.called
+    assert mock_llm.complete_async.called
 
-    call_args = mock_llm.send_async.call_args
-    llm_request = call_args[0][0]  # First arg is request object
-    prompt_content = llm_request.user_message
+    call_args = mock_llm.complete_async.call_args
+    prompt_content = call_args.kwargs.get("prompt", "") or call_args[1].get("prompt", "") if call_args[1] else ""
+    if not prompt_content and call_args[0]:
+        prompt_content = call_args[0][0]
 
     # Assertions: Check if semantic context is in the prompt
     print(f"Captured Prompt: {prompt_content}")

--- a/tests/llm/test_ollama_adaptive_timeout.py
+++ b/tests/llm/test_ollama_adaptive_timeout.py
@@ -152,20 +152,26 @@ class TestOllamaStatExtraction:
 
         mock_response.aiter_lines = fake_aiter_lines
 
-        mock_stream = AsyncMock()
+        mock_stream = MagicMock()
         mock_stream.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream.__aexit__ = AsyncMock(return_value=False)
 
         mock_client = MagicMock()
         mock_client.stream = MagicMock(return_value=mock_stream)
 
-        mock_async_client = AsyncMock()
+        mock_async_client = MagicMock()
         mock_async_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_async_client.__aexit__ = AsyncMock(return_value=False)
 
+        mock_sem = MagicMock()
+        mock_sem.__aenter__ = AsyncMock(return_value=None)
+        mock_sem.__aexit__ = AsyncMock(return_value=False)
+
+        mock_limiter = AsyncMock()
+        mock_limiter.concurrency_limit = MagicMock(return_value=mock_sem)
+
         with patch("warden.llm.providers.ollama.httpx.AsyncClient", return_value=mock_async_client):
             with patch("warden.llm.global_rate_limiter.GlobalRateLimiter") as mock_rl:
-                mock_limiter = AsyncMock()
                 mock_rl.get_instance = AsyncMock(return_value=mock_limiter)
                 response = await client.send_async(request)
 
@@ -201,20 +207,26 @@ class TestOllamaStatExtraction:
 
         mock_response.aiter_lines = fake_aiter_lines
 
-        mock_stream = AsyncMock()
+        mock_stream = MagicMock()
         mock_stream.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream.__aexit__ = AsyncMock(return_value=False)
 
         mock_client = MagicMock()
         mock_client.stream = MagicMock(return_value=mock_stream)
 
-        mock_async_client = AsyncMock()
+        mock_async_client = MagicMock()
         mock_async_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_async_client.__aexit__ = AsyncMock(return_value=False)
 
+        mock_sem = MagicMock()
+        mock_sem.__aenter__ = AsyncMock(return_value=None)
+        mock_sem.__aexit__ = AsyncMock(return_value=False)
+
+        mock_limiter = AsyncMock()
+        mock_limiter.concurrency_limit = MagicMock(return_value=mock_sem)
+
         with patch("warden.llm.providers.ollama.httpx.AsyncClient", return_value=mock_async_client):
             with patch("warden.llm.global_rate_limiter.GlobalRateLimiter") as mock_rl:
-                mock_limiter = AsyncMock()
                 mock_rl.get_instance = AsyncMock(return_value=mock_limiter)
                 response = await client.send_async(request)
 

--- a/tests/pipeline/application/orchestrator/test_frame_runner_timeout.py
+++ b/tests/pipeline/application/orchestrator/test_frame_runner_timeout.py
@@ -218,18 +218,18 @@ class TestCalculateBatchTimeout:
         return SimpleNamespace(size_bytes=size_bytes)
 
     def test_sums_per_file_timeouts(self):
-        """Five small files → each gets local floor (120s) → sum=600s, clamped to min 300s."""
+        """Five small files → each gets local floor (45s) → sum=225s, clamped to min 300s."""
         files = [self._make_file(100) for _ in range(5)]
         result = calculate_batch_timeout(files, provider="ollama")
-        # Each file with size 100 and ollama provider → _FILE_TIMEOUT_LOCAL_S = 120s
-        # Total = 5 × 120 = 600s, clamp(300, 1800) = 600s
-        assert result == 5 * _FILE_TIMEOUT_LOCAL_S
+        # Each file with size 100 and ollama provider → _FILE_TIMEOUT_LOCAL_S = 45s
+        # Total = 5 × 45 = 225s, clamp(300, 1800) = 300s
+        assert result == _BATCH_TIMEOUT_MIN_S
 
     def test_ollama_provider_uses_local_floor(self):
         """Ollama provider forces each file to at least _FILE_TIMEOUT_LOCAL_S."""
         files = [self._make_file(0)]
         result = calculate_batch_timeout(files, provider="ollama")
-        # sum = 120s, clamped to min 300s
+        # sum = 45s, clamped to min 300s
         assert result == _BATCH_TIMEOUT_MIN_S
 
     def test_min_clamp_300s(self):


### PR DESCRIPTION
## Summary
- **A1**: Fix `test_sums_per_file_timeouts` — 5×45=225 clamped to `_BATCH_TIMEOUT_MIN_S`(300)
- **A2**: Fix `test_ollama_adaptive_timeout` — `MagicMock` for async context managers (httpx client, stream, semaphore)
- **A3**: Fix `test_context_propagation` — use `complete_async`, patch classification cache
- **A4**: Bare `except:` → `except (ValueError, IndexError):` in `scan_output.py`
- **A5**: `print()` → `logger.warning()` in 3 build_context parsers
- **A6**: Silent `except: pass` → `logger.debug()` in `frame_runner.py`

Closes #402

## Test plan
- [x] `test_sums_per_file_timeouts` passes
- [x] `test_prefill_and_generation_populated` passes
- [x] `test_zero_timing_fields_produce_none` passes
- [x] `test_context_propagation` passes
- [x] 83 affected tests pass with 0 failures