### PR TITLE
refactor(llm): DRY duration calc and error response across 8 providers (#406)

### DIFF
--- a/src/warden/llm/providers/anthropic.py
+++ b/src/warden/llm/providers/anthropic.py
@@ -117,17 +117,11 @@ class AnthropicClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             # Validate response structure
             if not result.get("content"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from Anthropic",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from Anthropic", provider=self.provider, duration_ms=duration_ms)
 
             # Extract usage information
             usage = result.get("usage", {})
@@ -144,29 +138,23 @@ class AnthropicClient(ILlmClient):
             )
 
         except httpx.HTTPStatusError as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             response_text = e.response.text[:200] if e.response.text else "No response body"
             error_msg = f"HTTP {e.response.status_code}: {response_text}"
-            return LlmResponse(
-                content="", success=False, error_message=error_msg, provider=self.provider, duration_ms=duration_ms
-            )
+            return LlmResponse.error(error_msg, provider=self.provider, duration_ms=duration_ms)
 
         except (httpx.ConnectError, httpx.TimeoutException) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             # Transient connectivity issue — do not treat as permanent provider failure (#313)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"Connection error (transient): {type(e).__name__}",
+            return LlmResponse.error(
+                f"Connection error (transient): {type(e).__name__}",
                 provider=self.provider,
                 duration_ms=duration_ms,
             )
 
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def send_structured_async(self, structured: StructuredPrompt, request: LlmRequest) -> LlmResponse:
         """Send a request using a StructuredPrompt with cache_control hints.
@@ -209,16 +197,10 @@ class AnthropicClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("content"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from Anthropic",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from Anthropic", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
 
@@ -234,29 +216,23 @@ class AnthropicClient(ILlmClient):
             )
 
         except httpx.HTTPStatusError as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             response_text = e.response.text[:200] if e.response.text else "No response body"
             error_msg = f"HTTP {e.response.status_code}: {response_text}"
-            return LlmResponse(
-                content="", success=False, error_message=error_msg, provider=self.provider, duration_ms=duration_ms
-            )
+            return LlmResponse.error(error_msg, provider=self.provider, duration_ms=duration_ms)
 
         except (httpx.ConnectError, httpx.TimeoutException) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             # Transient connectivity issue — do not treat as permanent provider failure (#313)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"Connection error (transient): {type(e).__name__}",
+            return LlmResponse.error(
+                f"Connection error (transient): {type(e).__name__}",
                 provider=self.provider,
                 duration_ms=duration_ms,
             )
 
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         """

--- a/src/warden/llm/providers/deepseek.py
+++ b/src/warden/llm/providers/deepseek.py
@@ -59,16 +59,10 @@ class DeepSeekClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("choices"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from DeepSeek",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from DeepSeek", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
 
@@ -84,10 +78,8 @@ class DeepSeekClient(ILlmClient):
             )
 
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         try:

--- a/src/warden/llm/providers/gemini.py
+++ b/src/warden/llm/providers/gemini.py
@@ -86,7 +86,7 @@ class GeminiClient(ILlmClient):
 
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             # Extract content
             # Response: { candidates: [ { content: { parts: [ { text: "..." } ] } } ] }
@@ -99,10 +99,8 @@ class GeminiClient(ILlmClient):
 
             if not content:
                 # Check for safety ratings blocking
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message=f"No content generated. Response: {result}",
+                return LlmResponse.error(
+                    f"No content generated. Response: {result}",
                     provider=self.provider,
                     duration_ms=duration_ms,
                 )
@@ -122,20 +120,16 @@ class GeminiClient(ILlmClient):
             )
 
         except httpx.HTTPStatusError as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"HTTP {e.response.status_code}: {(e.response.text[:200] if e.response.text else 'No response body')}",
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(
+                f"HTTP {e.response.status_code}: {(e.response.text[:200] if e.response.text else 'No response body')}",
                 provider=self.provider,
                 duration_ms=duration_ms,
             )
 
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         """Check availability."""

--- a/src/warden/llm/providers/groq.py
+++ b/src/warden/llm/providers/groq.py
@@ -90,12 +90,9 @@ class GroqClient(ILlmClient):
                     remaining_seconds=round(remaining, 1),
                     reason="exceeds_timeout_budget",
                 )
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message=f"Groq rate limited — {remaining:.0f}s remaining, exceeds timeout budget",
+                return LlmResponse.error(
+                    f"Groq rate limited — {remaining:.0f}s remaining, exceeds timeout budget",
                     provider=self.provider,
-                    duration_ms=0,
                 )
             logger.info("groq_rate_limited_backoff", wait_seconds=round(remaining, 1))
             await asyncio.sleep(remaining)
@@ -108,12 +105,9 @@ class GroqClient(ILlmClient):
                 await limiter.acquire("groq", tokens=request.max_tokens + request.estimated_prompt_tokens)
             except asyncio.TimeoutError:
                 # Rate-limit queue timeout — skip this call, do not trip circuit breaker (#311)
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="Groq rate-limit queue timeout — provider skipped",
+                return LlmResponse.error(
+                    "Groq rate-limit queue timeout — provider skipped",
                     provider=self.provider,
-                    duration_ms=0,
                 )
 
             headers = {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
@@ -144,16 +138,10 @@ class GroqClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("choices"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from Groq",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from Groq", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
 
@@ -169,7 +157,7 @@ class GroqClient(ILlmClient):
             )
 
         except httpx.HTTPStatusError as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             body = e.response.text[:500] if e.response else ""
 
             if e.response is not None and e.response.status_code == 429:
@@ -181,26 +169,16 @@ class GroqClient(ILlmClient):
                     rate_limited_until=GroqClient._rate_limited_until,
                 )
                 logger.debug("groq_429_body", body=body)  # Body in debug only — may contain request echo (#312)
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message=f"Groq rate limited (429) — retry after {retry_after}s",
+                return LlmResponse.error(
+                    f"Groq rate limited (429) — retry after {retry_after}s",
                     provider=self.provider,
                     duration_ms=duration_ms,
                 )
 
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"{e} | body={body}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            return LlmResponse.error(f"{e} | body={body}", provider=self.provider, duration_ms=duration_ms)
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         try:

--- a/src/warden/llm/providers/ollama.py
+++ b/src/warden/llm/providers/ollama.py
@@ -100,12 +100,9 @@ class OllamaClient(ILlmClient):
 
         # Fail-fast: skip rate limiter + HTTP call for known-missing models
         if model in self._missing_models:
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"Model '{model}' not found. Run 'ollama pull {model}'.",
+            return LlmResponse.error(
+                f"Model '{model}' not found. Run 'ollama pull {model}'.",
                 provider=self.provider,
-                duration_ms=0,
             )
 
         try:
@@ -164,7 +161,7 @@ class OllamaClient(ILlmClient):
                                 gen_ns = chunk.get("eval_duration", 0)
                                 break
 
-                duration_ms = int((time.time() - start_time) * 1000)
+                duration_ms = LlmResponse.elapsed_ms(start_time)
                 content = "".join(content_parts)
 
                 return LlmResponse(
@@ -181,7 +178,7 @@ class OllamaClient(ILlmClient):
                 )
 
         except httpx.HTTPStatusError as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             if e.response.status_code == 404:
                 # Cache the missing model to fail-fast on subsequent calls
                 self._missing_models.add(model)
@@ -198,19 +195,15 @@ class OllamaClient(ILlmClient):
                 model=model,
                 duration_ms=duration_ms,
             )
-            return LlmResponse(
-                content="", success=False, error_message=error_msg, provider=self.provider, duration_ms=duration_ms
-            )
+            return LlmResponse.error(error_msg, provider=self.provider, duration_ms=duration_ms)
         except ModelNotFoundError:
             raise  # Don't wrap in generic handler
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
             # asyncio.TimeoutError.__str__() returns '' — show type name as fallback
             _err = str(e) or type(e).__name__
             logger.error("ollama_request_failed", error=_err, model=model, duration_ms=duration_ms)
-            return LlmResponse(
-                content="", success=False, error_message=_err, provider=self.provider, duration_ms=duration_ms
-            )
+            return LlmResponse.error(_err, provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         """

--- a/src/warden/llm/providers/openai.py
+++ b/src/warden/llm/providers/openai.py
@@ -94,12 +94,9 @@ class OpenAIClient(ILlmClient):
                 await limiter.acquire(provider_name, tokens=request.max_tokens + request.estimated_prompt_tokens)
             except asyncio.TimeoutError:
                 # Rate-limit queue timeout — skip this call, do not trip circuit breaker (#311)
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message=f"{provider_name} rate-limit queue timeout — provider skipped",
+                return LlmResponse.error(
+                    f"{provider_name} rate-limit queue timeout — provider skipped",
                     provider=self.provider,
-                    duration_ms=0,
                 )
 
             headers = {"Content-Type": "application/json"}
@@ -129,16 +126,10 @@ class OpenAIClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("choices"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from OpenAI",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from OpenAI", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
             prompt_tokens = usage.get("prompt_tokens", 0)
@@ -163,33 +154,15 @@ class OpenAIClient(ILlmClient):
             )
 
         except (httpx.HTTPStatusError, httpx.RequestError) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"HTTP error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"HTTP error: {e!s}", provider=self.provider, duration_ms=duration_ms)
         except (json.JSONDecodeError, KeyError) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"JSON/Data error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"JSON/Data error: {e!s}", provider=self.provider, duration_ms=duration_ms)
         except Exception as e:
             # Last resort for truly unexpected errors
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"Unexpected error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"Unexpected error: {e!s}", provider=self.provider, duration_ms=duration_ms)
 
     async def send_structured_async(self, structured: StructuredPrompt, request: LlmRequest) -> LlmResponse:
         """Send a request using a StructuredPrompt with cache-friendly layout.
@@ -237,16 +210,10 @@ class OpenAIClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("choices"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from OpenAI",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from OpenAI", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
             prompt_tokens = usage.get("prompt_tokens", 0)
@@ -270,32 +237,14 @@ class OpenAIClient(ILlmClient):
             )
 
         except (httpx.HTTPStatusError, httpx.RequestError) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"HTTP error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"HTTP error: {e!s}", provider=self.provider, duration_ms=duration_ms)
         except (json.JSONDecodeError, KeyError) as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"JSON/Data error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"JSON/Data error: {e!s}", provider=self.provider, duration_ms=duration_ms)
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="",
-                success=False,
-                error_message=f"Unexpected error: {e!s}",
-                provider=self.provider,
-                duration_ms=duration_ms,
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(f"Unexpected error: {e!s}", provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         """

--- a/src/warden/llm/providers/orchestrated.py
+++ b/src/warden/llm/providers/orchestrated.py
@@ -205,7 +205,7 @@ class OrchestratedLlmClient(ILlmClient):
 
                     start_time = time.time()
                     response = await client.send_async(provider_request)
-                    duration_ms = int((time.time() - start_time) * 1000)
+                    duration_ms = LlmResponse.elapsed_ms(start_time)
 
                     # Record circuit breaker state based on response
                     if response.success:
@@ -338,7 +338,7 @@ class OrchestratedLlmClient(ILlmClient):
 
         start_time = time.time()
         response = await self.smart_client.send_async(smart_request)
-        duration_ms = int((time.time() - start_time) * 1000)
+        duration_ms = LlmResponse.elapsed_ms(start_time)
 
         # Record circuit breaker state for smart tier
         if response.success:

--- a/src/warden/llm/providers/qwencode.py
+++ b/src/warden/llm/providers/qwencode.py
@@ -57,16 +57,10 @@ class QwenCodeClient(ILlmClient):
                 response.raise_for_status()
                 result = response.json()
 
-            duration_ms = int((time.time() - start_time) * 1000)
+            duration_ms = LlmResponse.elapsed_ms(start_time)
 
             if not result.get("output") or not result["output"].get("text"):
-                return LlmResponse(
-                    content="",
-                    success=False,
-                    error_message="No response from QwenCode",
-                    provider=self.provider,
-                    duration_ms=duration_ms,
-                )
+                return LlmResponse.error("No response from QwenCode", provider=self.provider, duration_ms=duration_ms)
 
             usage = result.get("usage", {})
 
@@ -82,10 +76,8 @@ class QwenCodeClient(ILlmClient):
             )
 
         except Exception as e:
-            duration_ms = int((time.time() - start_time) * 1000)
-            return LlmResponse(
-                content="", success=False, error_message=str(e), provider=self.provider, duration_ms=duration_ms
-            )
+            duration_ms = LlmResponse.elapsed_ms(start_time)
+            return LlmResponse.error(str(e), provider=self.provider, duration_ms=duration_ms)
 
     async def is_available_async(self) -> bool:
         try:

--- a/src/warden/llm/types.py
+++ b/src/warden/llm/types.py
@@ -5,6 +5,9 @@ Multi-provider LLM support with fallback chain.
 All types designed for Panel JSON compatibility (camelCase <-> snake_case).
 """
 
+from __future__ import annotations
+
+import time
 from dataclasses import dataclass
 from enum import Enum
 
@@ -94,6 +97,27 @@ class LlmResponse(BaseDomainModel):
     overall_confidence: float | None = None
     prefill_duration_ms: float | None = None  # Ollama: prompt_eval_duration / 1e6
     generation_duration_ms: float | None = None  # Ollama: eval_duration / 1e6
+
+    @classmethod
+    def error(
+        cls,
+        message: str,
+        provider: LlmProvider | None = None,
+        duration_ms: int = 0,
+    ) -> LlmResponse:
+        """Create a failed response."""
+        return cls(
+            content="",
+            success=False,
+            error_message=message,
+            provider=provider,
+            duration_ms=duration_ms,
+        )
+
+    @staticmethod
+    def elapsed_ms(start_time: float) -> int:
+        """Milliseconds elapsed since *start_time* (from ``time.time()``)."""
+        return int((time.time() - start_time) * 1000)
 
 
 class AnalysisIssue(BaseDomainModel):


### PR DESCRIPTION
## Summary
- Add `LlmResponse.error()` class method — factory for failed responses
- Add `LlmResponse.elapsed_ms()` — replaces `int((time.time() - start_time) * 1000)`
- Refactor 8 providers: anthropic, openai, groq, ollama, gemini, deepseek, qwencode, orchestrated
- Net -102 lines

Closes #406

## Test plan
- [x] 299 LLM tests pass, 0 failures
- [x] Zero remaining inline `int((time.time() - start_time) * 1000)` in providers/