### PR TITLE
refactor(config): add typed tpm_limit/rpm_limit to LlmConfiguration (#408)

### DIFF
--- a/src/warden/llm/config.py
+++ b/src/warden/llm/config.py
@@ -106,6 +106,10 @@ class LlmConfiguration:
     smart_tier_model: str | None = None  # Model for the smart tier provider override
     max_concurrency: int = 4  # Global max concurrent requests
 
+    # Rate limits (used by LLMPhaseConfig in analysis/classification executors)
+    tpm_limit: int = 1000  # Tokens per minute (free-tier default)
+    rpm_limit: int = 6  # Requests per minute (free-tier default)
+
     # Centralized token budgets for all LLM consumers (triage-aware).
     # Keys: category name → {"deep": int, "fast": int}
     # Overrides built-in defaults in warden.shared.utils.llm_context.DEFAULT_TOKEN_BUDGETS.
@@ -631,6 +635,14 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
 
         if "fast_model" in config_override and not env_provider:
             config.fast_model = config_override["fast_model"]
+
+        # Rate limits from config.yaml
+        if "tpm_limit" in config_override:
+            with contextlib.suppress(ValueError, TypeError):
+                config.tpm_limit = int(config_override["tpm_limit"])
+        if "rpm_limit" in config_override:
+            with contextlib.suppress(ValueError, TypeError):
+                config.rpm_limit = int(config_override["rpm_limit"])
 
         # Smart tier provider override from config.yaml (env var takes precedence)
         if "smart_tier_provider" in config_override and not config.smart_tier_provider:

--- a/src/warden/pipeline/application/executors/analysis_executor.py
+++ b/src/warden/pipeline/application/executors/analysis_executor.py
@@ -75,12 +75,8 @@ class AnalysisExecutor(BasePhaseExecutor):
                         config=LLMPhaseConfig(
                             enabled=True,
                             fallback_to_rules=True,
-                            tpm_limit=self.config.llm_config.get("tpm_limit", 1000)
-                            if getattr(self.config, "llm_config", None)
-                            else (getattr(self.config.llm, "tpm_limit", 1000) if hasattr(self.config, "llm") else 1000),
-                            rpm_limit=self.config.llm_config.get("rpm_limit", 6)
-                            if getattr(self.config, "llm_config", None)
-                            else (getattr(self.config.llm, "rpm_limit", 6) if hasattr(self.config, "llm") else 6),
+                            tpm_limit=self.config.get_tpm_limit(),
+                            rpm_limit=self.config.get_rpm_limit(),
                         ),
                         llm_service=self.llm_service,
                         project_root=self.project_root,

--- a/src/warden/pipeline/application/executors/classification_executor.py
+++ b/src/warden/pipeline/application/executors/classification_executor.py
@@ -74,12 +74,8 @@ class ClassificationExecutor(BasePhaseExecutor):
                         config=LLMPhaseConfig(
                             enabled=True,
                             fallback_to_rules=True,
-                            tpm_limit=self.config.llm_config.get("tpm_limit", 1000)
-                            if getattr(self.config, "llm_config", None)
-                            else (getattr(self.config.llm, "tpm_limit", 1000) if hasattr(self.config, "llm") else 1000),
-                            rpm_limit=self.config.llm_config.get("rpm_limit", 6)
-                            if getattr(self.config, "llm_config", None)
-                            else (getattr(self.config.llm, "rpm_limit", 6) if hasattr(self.config, "llm") else 6),
+                            tpm_limit=self.config.get_tpm_limit(),
+                            rpm_limit=self.config.get_rpm_limit(),
                         ),
                         llm_service=self.llm_service,
                         available_frames=self.available_frames,

--- a/src/warden/pipeline/domain/models.py
+++ b/src/warden/pipeline/domain/models.py
@@ -99,6 +99,20 @@ class PipelineConfig(BaseDomainModel):
     semantic_search_config: dict[str, Any] | None = None  # Configuration for semantic search service
     llm_config: dict[str, Any] | None = None  # LLM configuration (tpm, rpm, etc.)
 
+    def get_tpm_limit(self) -> int:
+        """Resolve tpm_limit: llm_config dict > llm typed config > default 1000."""
+        if self.llm_config:
+            return int(self.llm_config.get("tpm_limit", 1000))
+        llm = getattr(self, "llm", None)
+        return getattr(llm, "tpm_limit", 1000) if llm else 1000
+
+    def get_rpm_limit(self) -> int:
+        """Resolve rpm_limit: llm_config dict > llm typed config > default 6."""
+        if self.llm_config:
+            return int(self.llm_config.get("rpm_limit", 6))
+        llm = getattr(self, "llm", None)
+        return getattr(llm, "rpm_limit", 6) if llm else 6
+
     # LSP Integration (NEW!)
     lsp_config: dict[str, Any] | None = None  # LSP integration configuration (enabled, servers)
 


### PR DESCRIPTION
## Summary
- Add `tpm_limit` and `rpm_limit` fields to `LlmConfiguration` (config.yaml parsing)
- Add `PipelineConfig.get_tpm_limit()`/`get_rpm_limit()` helpers
- Replace duplicated 3-way ternary chains in analysis_executor and classification_executor

Closes #408

## Test plan
- [x] 586 llm/config/pipeline unit tests pass
- [x] Orchestrator integration tests have pre-existing failures (unrelated)