### PR TITLE
fix(docs): remove broken links and correct misleading claims in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Warden's **Engine** runs on Python/Rust, but it validates code across multiple l
 
 | Tier | Languages | AST | Taint Analysis | Security Rules | Frameworks |
 | :--- | :--- | :---: | :---: | :---: | :--- |
-| **Tier 1 — Full** | Python, JavaScript/TypeScript | ✅ | ✅ Interprocedural (Python) / Regex (JS) | 17 rules | Flask, Django, FastAPI, Express, Koa |
+| **Tier 1 — Full** | Python, JavaScript/TypeScript | ✅ | ✅ Interprocedural (Python) / Regex (JS) | 8 security checks | Flask, Django, FastAPI, Express, Koa |
 | **Tier 2 — Standard** | Go, Java | ✅ | ✅ Regex-based | Via LLM | stdlib, Spring |
 | **Tier 3 — Basic** | Kotlin, Dart | ✅ | ❌ | Via LLM | — |
 | **Tier 4 — Regex Only** | Swift, C/C++, Ruby, PHP | ❌ | ❌ | Regex patterns | — |
@@ -131,7 +131,7 @@ llm:
 - **Parallel execution** automatically races all fast providers
 
 ### 4. 🛡️ Core Validation Frames (Built-in)
-Warden ships with 6 powerful core frames:
+Warden ships with **13+ validation frames**, including these core frames:
 1.  **SecurityFrame:** Detects vulnerabilities (SQLi, Secrets, XSS) with **multi-language taint analysis**.
 2.  **ResilienceFrame:** Validates error handling, retry, and circuit-breaker patterns.
 3.  **ArchitecturalFrame:** Enforces project structure and clean code references.
@@ -686,7 +686,7 @@ We are transforming Warden from a local tool into a global **Standard of Trust**
 *   Phase 3: Warden Cloud Registry ☁️
 *   Phase 4: Enterprise Compliance 🏢
 
-[See full usage plan in ROADMAP.md](./ROADMAP.md)
+
 
 2.  **Architectural Frames:**
     We don't just look for bugs. We look for **Architectural Crimes**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 authors = [{name = "Warden Team", email = "warden-core@proton.me"}]
 license = {text = "Apache-2.0"}
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",
@@ -90,7 +90,7 @@ warden = "warden.main:main"
 
 [tool.setuptools_scm]
 write_to = "src/warden/_version.py"
-fallback_version = "2.3.0"
+fallback_version = "2.4.0"
 
 # ============================================================
 # Ruff - Fast Python linter and formatter


### PR DESCRIPTION
## Summary
- Remove dead `ROADMAP.md` link (file doesn't exist)
- Fix "17 rules" → "8 security checks" (verified: 8 registered `ValidationCheck` subclasses)
- Fix "6 frames" → "13+ frames" (verified: 13+ frames in `validation/frames/`)
- Fix PyPI classifier `Alpha` → `Beta` (matches README badge)
- Fix `fallback_version` `2.3.0` → `2.4.0` (matches declared version)

Closes #450

## Test plan
- [x] e2e scan output tests pass (34 passed)
- [x] No code changes, only docs/metadata