### PR TITLE
fix(llm): remove dead OpenRouter provider enum

### DIFF
--- a/src/warden/analysis/application/triage_service.py
+++ b/src/warden/analysis/application/triage_service.py
@@ -34,7 +34,6 @@ _BATCH_SIZES: dict[str, int] = {
     "openai": 15,  # Cloud API, 128K context
     "azure_openai": 15,
     "anthropic": 15,
-    "openrouter": 15,
     "deepseek": 15,
     "qwencode": 15,
     "gemini": 15,

--- a/src/warden/llm/config.py
+++ b/src/warden/llm/config.py
@@ -2,7 +2,7 @@
 LLM Configuration
 
 Supports multi-provider configuration with fallback chain.
-Providers: DeepSeek, QwenCode, Anthropic, OpenAI, Azure OpenAI, Groq, OpenRouter
+Providers: DeepSeek, QwenCode, Anthropic, OpenAI, Azure OpenAI, Groq
 """
 
 import contextlib
@@ -93,7 +93,6 @@ class LlmConfiguration:
     openai: ProviderConfig = field(default_factory=ProviderConfig)
     azure_openai: ProviderConfig = field(default_factory=ProviderConfig)
     groq: ProviderConfig = field(default_factory=ProviderConfig)
-    openrouter: ProviderConfig = field(default_factory=ProviderConfig)
     ollama: ProviderConfig = field(default_factory=ProviderConfig)
     claude_code: ProviderConfig = field(default_factory=ProviderConfig)  # Local Claude Code CLI/SDK
     codex: ProviderConfig = field(default_factory=ProviderConfig)  # Local Codex CLI
@@ -139,7 +138,6 @@ class LlmConfiguration:
             LlmProvider.OPENAI: self.openai,
             LlmProvider.AZURE_OPENAI: self.azure_openai,
             LlmProvider.GROQ: self.groq,
-            LlmProvider.OPENROUTER: self.openrouter,
             LlmProvider.OLLAMA: self.ollama,
             LlmProvider.CLAUDE_CODE: self.claude_code,
             LlmProvider.CODEX: self.codex,
@@ -186,7 +184,6 @@ DEFAULT_MODELS = {
     LlmProvider.OPENAI: "gpt-4o",
     LlmProvider.AZURE_OPENAI: "gpt-4o",
     LlmProvider.GROQ: "llama-3.3-70b-versatile",
-    LlmProvider.OPENROUTER: "anthropic/claude-3.5-sonnet",
     LlmProvider.OLLAMA: "qwen2.5-coder:3b",
     LlmProvider.CLAUDE_CODE: "claude-code-default",  # Placeholder - actual model controlled by `claude config`
     LlmProvider.CODEX: "codex-local",  # Placeholder - actual model controlled by ~/.codex/config.toml
@@ -394,7 +391,6 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
             "DEEPSEEK_API_KEY",
             "QWENCODE_API_KEY",
             "GROQ_API_KEY",
-            "OPENROUTER_API_KEY",
             "WARDEN_SMART_MODEL",
             "WARDEN_FAST_MODEL",
             "WARDEN_LLM_CONCURRENCY",
@@ -493,13 +489,6 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
         config.groq.api_key = groq_secret.value
         config.groq.enabled = True
         configured_providers.append(LlmProvider.GROQ)
-
-    # Configure OpenRouter
-    openrouter_secret = secrets.get("OPENROUTER_API_KEY")
-    if openrouter_secret and openrouter_secret.found:
-        config.openrouter.api_key = openrouter_secret.value
-        config.openrouter.enabled = True
-        configured_providers.append(LlmProvider.OPENROUTER)
 
     # Configure Ollama (Local)
     try:
@@ -617,7 +606,6 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
             config.deepseek,
             config.qwencode,
             config.groq,
-            config.openrouter,
         ]:
             provider_config.enabled = False
 

--- a/src/warden/llm/types.py
+++ b/src/warden/llm/types.py
@@ -25,7 +25,6 @@ class LlmProvider(str, Enum):
     OPENAI = "openai"
     AZURE_OPENAI = "azure_openai"
     GROQ = "groq"
-    OPENROUTER = "openrouter"
     OLLAMA = "ollama"
     GEMINI = "gemini"
     CLAUDE_CODE = "claude_code"  # Local Claude Code CLI/SDK integration

--- a/src/warden/mcp/infrastructure/adapters/config_adapter.py
+++ b/src/warden/mcp/infrastructure/adapters/config_adapter.py
@@ -104,7 +104,7 @@ class ConfigAdapter(BaseWardenAdapter):
                 properties={
                     "provider": {
                         "type": "string",
-                        "description": "LLM Provider (ollama, openai, anthropic, gemini, azure_openai, deepseek, groq, openrouter)",
+                        "description": "LLM Provider (ollama, openai, anthropic, gemini, azure_openai, deepseek, groq)",
                     },
                     "api_key": {
                         "type": "string",
@@ -275,7 +275,7 @@ class ConfigAdapter(BaseWardenAdapter):
         model = arguments.get("model")
         vector_db = arguments.get("vector_db", "local")
 
-        valid_providers = {"ollama", "openai", "anthropic", "gemini", "azure_openai", "deepseek", "groq", "openrouter"}
+        valid_providers = {"ollama", "openai", "anthropic", "gemini", "azure_openai", "deepseek", "groq"}
 
         if provider not in valid_providers:
             return MCPToolResult.error(f"Invalid provider: {provider}. Must be one of: {', '.join(valid_providers)}")
@@ -292,7 +292,6 @@ class ConfigAdapter(BaseWardenAdapter):
                 "azure_openai": "AZURE_OPENAI_API_KEY",
                 "deepseek": "DEEPSEEK_API_KEY",
                 "groq": "GROQ_API_KEY",
-                "openrouter": "OPENROUTER_API_KEY",
             }
             if provider in key_map:
                 env_updates[key_map[provider]] = api_key

--- a/src/warden/mcp/infrastructure/adapters/health_adapter.py
+++ b/src/warden/mcp/infrastructure/adapters/health_adapter.py
@@ -402,7 +402,6 @@ class HealthAdapter(BaseWardenAdapter):
             "azure_openai": "AZURE_OPENAI_API_KEY",
             "deepseek": "DEEPSEEK_API_KEY",
             "groq": "GROQ_API_KEY",
-            "openrouter": "OPENROUTER_API_KEY",
             "google": "GOOGLE_API_KEY",
             "gemini": "GOOGLE_API_KEY",
             "cohere": "COHERE_API_KEY",

--- a/tests/e2e/test_acceptance.py
+++ b/tests/e2e/test_acceptance.py
@@ -3929,7 +3929,7 @@ class TestBlockedProviders:
             str(vuln),
             cwd=str(isolated_sample),
             timeout=60,
-            env={"WARDEN_BLOCKED_PROVIDERS": "claude_code,openrouter"},
+            env={"WARDEN_BLOCKED_PROVIDERS": "claude_code,groq"},
         )
         assert r.returncode in (0, 1, 2), f"Multi-block scan crashed: rc={r.returncode}\n{r.stderr}"
         assert "Traceback" not in r.stdout + r.stderr

--- a/tests/e2e/test_llm_provider.py
+++ b/tests/e2e/test_llm_provider.py
@@ -107,15 +107,6 @@ class TestLLMProviderSwitch:
         config = yaml.safe_load((isolated_project / ".warden/config.yaml").read_text())
         assert config["llm"]["provider"] == "azure_openai"
 
-    def test_config_set_llm_provider_openrouter(self, runner, isolated_project, monkeypatch):
-        """Switch provider to openrouter."""
-        monkeypatch.chdir(isolated_project)
-        result = runner.invoke(app, ["config", "set", "llm.provider", "openrouter"], catch_exceptions=False)
-        assert result.exit_code == 0
-
-        config = yaml.safe_load((isolated_project / ".warden/config.yaml").read_text())
-        assert config["llm"]["provider"] == "openrouter"
-
     def test_config_set_llm_provider_gemini(self, runner, isolated_project, monkeypatch):
         """Switch provider to gemini."""
         monkeypatch.chdir(isolated_project)


### PR DESCRIPTION
## Summary
- Remove `OPENROUTER` from `LlmProvider` enum (no implementation exists)
- Remove config field, default model, secret loading, MCP adapter entries
- Remove from triage batch sizes and test references
- Prevents `ValueError` crash when `OPENROUTER_API_KEY` is set

Closes #426

## Test plan
- [x] All compile checks pass
- [x] e2e LLM provider tests pass (36 passed)
- [x] No other provider affected