### PR TITLE
feat(llm): add rate limiting for LLM API calls

### DIFF
--- a/src/warden/llm/config.py
+++ b/src/warden/llm/config.py
@@ -716,4 +716,15 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
         config.fast_tier_providers = []
         logger.debug("fast_tier_cleared_single_provider_mode", provider=config.default_provider.value)
 
+    # FINAL: Propagate project-level rate limits (tpm_limit/rpm_limit) to the
+    # global rate limiter so that free-tier config.yaml settings take effect for
+    # all providers that fall through to the "default" bucket. (#429)
+    try:
+        from warden.llm.global_rate_limiter import GlobalRateLimiter
+
+        grl = await GlobalRateLimiter.get_instance()
+        grl.configure_from_llm_config(config)
+    except Exception as _rl_err:  # pragma: no cover — never crash config loading
+        logger.debug("global_rate_limiter_configure_failed", error=str(_rl_err))
+
     return config

--- a/src/warden/llm/global_rate_limiter.py
+++ b/src/warden/llm/global_rate_limiter.py
@@ -5,13 +5,20 @@ Provides a thread-safe global rate limiter for all LLM providers.
 Prevents rate limit violations across the entire application.
 
 Issue #17 Fix: Global rate limiting implementation
+Issue #429 Fix: Wire LlmConfiguration tpm_limit/rpm_limit into GlobalRateLimiter
 """
 
 import asyncio
+import logging
 import threading
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from warden.llm.rate_limiter import RateLimitConfig, RateLimiter
+
+if TYPE_CHECKING:
+    from warden.llm.config import LlmConfiguration
+
+_logger = logging.getLogger(__name__)
 
 # Module-level threading lock for safe singleton initialization.
 # Threading lock is safe across event loops unlike asyncio.Lock.
@@ -138,6 +145,30 @@ class GlobalRateLimiter:
             RateLimiter instance for the provider
         """
         return self._limiters.get(provider.lower(), self._limiters["default"])
+
+    def configure_from_llm_config(self, config: "LlmConfiguration") -> None:
+        """Update the default rate limiter limits from LlmConfiguration.
+
+        Applies ``config.tpm_limit`` and ``config.rpm_limit`` to the
+        ``"default"`` bucket so that project-level config.yaml settings
+        (e.g. free-tier 6 rpm / 1000 tpm) take effect globally.
+
+        Provider-specific limiters (openai, anthropic, …) are intentionally
+        left unchanged — they reflect the provider's own published limits.
+        Projects that need stricter per-provider control can extend this
+        method in the future.
+
+        Args:
+            config: Loaded LlmConfiguration instance.
+        """
+        tpm = max(1, config.tpm_limit)
+        rpm = max(1, config.rpm_limit)
+        self._limiters["default"] = RateLimiter(RateLimitConfig(tpm=tpm, rpm=rpm))
+        _logger.debug(
+            "global_rate_limiter_configured",
+            tpm_limit=tpm,
+            rpm_limit=rpm,
+        )
 
     def get_stats(self, provider: str = "default") -> dict:
         """

--- a/src/warden/llm/providers/qwencode.py
+++ b/src/warden/llm/providers/qwencode.py
@@ -37,6 +37,11 @@ class QwenCodeClient(ILlmClient):
         start_time = time.time()
 
         try:
+            from warden.llm.global_rate_limiter import GlobalRateLimiter
+
+            limiter = await GlobalRateLimiter.get_instance()
+            await limiter.acquire("qwen", tokens=request.max_tokens + request.estimated_prompt_tokens)
+
             headers = {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
 
             payload = {

--- a/tests/llm/test_rate_limiting_429.py
+++ b/tests/llm/test_rate_limiting_429.py
@@ -1,0 +1,289 @@
+"""
+Tests for issue #429: rate limiting wired from LlmConfiguration into GlobalRateLimiter,
+and QwenCodeClient rate-limit integration.
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from warden.llm.global_rate_limiter import GlobalRateLimiter
+from warden.llm.rate_limiter import RateLimitConfig, RateLimiter
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_global_rate_limiter():
+    """Ensure a clean singleton for every test."""
+    GlobalRateLimiter.reset_instance()
+    yield
+    GlobalRateLimiter.reset_instance()
+
+
+# ---------------------------------------------------------------------------
+# configure_from_llm_config
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureFromLlmConfig:
+    """GlobalRateLimiter.configure_from_llm_config() wires LlmConfiguration limits."""
+
+    def _make_config(self, tpm: int = 1000, rpm: int = 6):
+        """Minimal config object with tpm_limit / rpm_limit attributes."""
+        cfg = MagicMock()
+        cfg.tpm_limit = tpm
+        cfg.rpm_limit = rpm
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_configure_updates_default_bucket_tpm(self):
+        """After configure_from_llm_config, default limiter uses new tpm_limit."""
+        limiter = await GlobalRateLimiter.get_instance()
+        cfg = self._make_config(tpm=2500, rpm=15)
+
+        limiter.configure_from_llm_config(cfg)
+
+        stats = limiter.get_stats("default")
+        assert stats["tpm"] == 2500
+
+    @pytest.mark.asyncio
+    async def test_configure_updates_default_bucket_rpm(self):
+        """After configure_from_llm_config, default limiter uses new rpm_limit."""
+        limiter = await GlobalRateLimiter.get_instance()
+        cfg = self._make_config(tpm=5000, rpm=20)
+
+        limiter.configure_from_llm_config(cfg)
+
+        stats = limiter.get_stats("default")
+        assert stats["rpm"] == 20
+
+    @pytest.mark.asyncio
+    async def test_configure_replaces_default_limiter_object(self):
+        """configure_from_llm_config replaces the default RateLimiter instance."""
+        limiter = await GlobalRateLimiter.get_instance()
+        original = limiter.get_limiter("default")
+        cfg = self._make_config(tpm=9999, rpm=42)
+
+        limiter.configure_from_llm_config(cfg)
+
+        new = limiter.get_limiter("default")
+        assert new is not original
+        assert new.config.tpm == 9999
+        assert new.config.rpm == 42
+
+    @pytest.mark.asyncio
+    async def test_configure_does_not_change_provider_specific_limits(self):
+        """configure_from_llm_config must not alter provider-specific buckets."""
+        limiter = await GlobalRateLimiter.get_instance()
+        openai_before = limiter.get_stats("openai")
+        anthropic_before = limiter.get_stats("anthropic")
+
+        cfg = self._make_config(tpm=100, rpm=2)
+        limiter.configure_from_llm_config(cfg)
+
+        # Provider-specific limits unchanged
+        assert limiter.get_stats("openai")["tpm"] == openai_before["tpm"]
+        assert limiter.get_stats("anthropic")["tpm"] == anthropic_before["tpm"]
+
+    @pytest.mark.asyncio
+    async def test_configure_clamps_zero_tpm_to_one(self):
+        """Degenerate config (tpm=0) must not create a zero-rate limiter."""
+        limiter = await GlobalRateLimiter.get_instance()
+        cfg = self._make_config(tpm=0, rpm=0)
+
+        limiter.configure_from_llm_config(cfg)
+
+        stats = limiter.get_stats("default")
+        assert stats["tpm"] >= 1
+        assert stats["rpm"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_configure_free_tier_defaults(self):
+        """config.yaml free-tier defaults (tpm=1000, rpm=6) work correctly."""
+        limiter = await GlobalRateLimiter.get_instance()
+        cfg = self._make_config(tpm=1000, rpm=6)
+
+        limiter.configure_from_llm_config(cfg)
+
+        stats = limiter.get_stats("default")
+        assert stats["tpm"] == 1000
+        assert stats["rpm"] == 6
+
+
+# ---------------------------------------------------------------------------
+# QwenCodeClient rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestQwenCodeClientRateLimiting:
+    """QwenCodeClient.send_async must call GlobalRateLimiter.acquire before the HTTP call."""
+
+    def _make_provider_config(self):
+        cfg = MagicMock()
+        cfg.api_key = "test-api-key-1234567890"
+        cfg.default_model = "qwen2.5-coder-32b-instruct"
+        cfg.endpoint = None
+        return cfg
+
+    @pytest.mark.asyncio
+    async def test_send_async_calls_rate_limiter_acquire(self):
+        """send_async must acquire the 'qwen' rate limiter before every HTTP call."""
+        from warden.llm.providers.qwencode import QwenCodeClient
+        from warden.llm.types import LlmRequest
+
+        client = QwenCodeClient(self._make_provider_config())
+
+        # Mock GlobalRateLimiter singleton
+        mock_limiter = AsyncMock()
+        mock_limiter.acquire = AsyncMock()
+
+        # Mock successful HTTP response
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "output": {"text": "Hello"},
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+
+        with patch(
+            "warden.llm.global_rate_limiter.GlobalRateLimiter.get_instance",
+            new=AsyncMock(return_value=mock_limiter),
+        ):
+            with patch("httpx.AsyncClient") as mock_http:
+                mock_http.return_value.__aenter__ = AsyncMock(return_value=MagicMock(post=AsyncMock(return_value=mock_response)))
+                mock_http.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                request = LlmRequest(
+                    user_message="test",
+                    system_prompt="sys",
+                    max_tokens=100,
+                )
+                await client.send_async(request)
+
+        # Verify rate limiter was called
+        mock_limiter.acquire.assert_called_once()
+        call_kwargs = mock_limiter.acquire.call_args
+        # First positional arg must be "qwen"
+        assert call_kwargs[0][0] == "qwen" or call_kwargs[1].get("provider") == "qwen" or (
+            len(call_kwargs[0]) > 0 and call_kwargs[0][0] == "qwen"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_async_rate_limiter_failure_returns_error_response(self):
+        """If GlobalRateLimiter raises, send_async must return an error LlmResponse."""
+        from warden.llm.providers.qwencode import QwenCodeClient
+        from warden.llm.types import LlmRequest
+
+        client = QwenCodeClient(self._make_provider_config())
+
+        mock_limiter = AsyncMock()
+        mock_limiter.acquire = AsyncMock(side_effect=asyncio.TimeoutError("rate limit timeout"))
+
+        with patch(
+            "warden.llm.global_rate_limiter.GlobalRateLimiter.get_instance",
+            new=AsyncMock(return_value=mock_limiter),
+        ):
+            request = LlmRequest(
+                user_message="test",
+                system_prompt="sys",
+                max_tokens=100,
+            )
+            response = await client.send_async(request)
+
+        assert response.success is False
+        assert response.error_message is not None
+
+    @pytest.mark.asyncio
+    async def test_send_async_passes_token_count_to_acquire(self):
+        """Rate limiter acquire must be called with max_tokens + estimated tokens."""
+        from warden.llm.providers.qwencode import QwenCodeClient
+        from warden.llm.types import LlmRequest
+
+        client = QwenCodeClient(self._make_provider_config())
+
+        acquired_tokens: list[int] = []
+        mock_limiter = AsyncMock()
+
+        async def capture_acquire(provider, tokens=0):
+            acquired_tokens.append(tokens)
+
+        mock_limiter.acquire = capture_acquire
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "output": {"text": "pong"},
+            "usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+        }
+
+        with patch(
+            "warden.llm.global_rate_limiter.GlobalRateLimiter.get_instance",
+            new=AsyncMock(return_value=mock_limiter),
+        ):
+            with patch("httpx.AsyncClient") as mock_http:
+                mock_http.return_value.__aenter__ = AsyncMock(
+                    return_value=MagicMock(post=AsyncMock(return_value=mock_response))
+                )
+                mock_http.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                request = LlmRequest(
+                    user_message="ping",
+                    system_prompt="sys",
+                    max_tokens=200,
+                )
+                await client.send_async(request)
+
+        assert len(acquired_tokens) == 1
+        # tokens = max_tokens + estimated_prompt_tokens (>= max_tokens)
+        assert acquired_tokens[0] >= 200
+
+
+# ---------------------------------------------------------------------------
+# load_llm_config_async wires GlobalRateLimiter (integration smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadLlmConfigAsyncWiresRateLimiter:
+    """load_llm_config_async must call configure_from_llm_config on GlobalRateLimiter."""
+
+    @pytest.mark.asyncio
+    async def test_load_config_async_configures_global_rate_limiter(self):
+        """Smoke test: after load_llm_config_async, GlobalRateLimiter default
+        bucket reflects tpm_limit / rpm_limit from the override dict."""
+        from warden.llm.config import load_llm_config_async
+
+        config_override = {
+            "tpm_limit": 3333,
+            "rpm_limit": 11,
+        }
+
+        # Patch secrets manager so we don't need real API keys
+        mock_secret = MagicMock()
+        mock_secret.found = False
+        mock_secret.value = None
+
+        async def fake_get_secrets(keys):
+            return {k: mock_secret for k in keys}
+
+        with patch("warden.secrets.get_manager") as mock_mgr:
+            manager_instance = MagicMock()
+            manager_instance.get_secrets_async = fake_get_secrets
+            mock_mgr.return_value = manager_instance
+
+            # Prevent live Ollama / claude / codex checks
+            with patch("warden.llm.config._check_ollama_availability", return_value=False):
+                with patch("warden.llm.config._check_claude_code_availability", return_value=False):
+                    with patch("warden.llm.config._check_codex_availability", return_value=False):
+                        await load_llm_config_async(config_override)
+
+        limiter = await GlobalRateLimiter.get_instance()
+        stats = limiter.get_stats("default")
+        assert stats["tpm"] == 3333
+        assert stats["rpm"] == 11


### PR DESCRIPTION
## Summary

- Add `GlobalRateLimiter.configure_from_llm_config()` to wire `LlmConfiguration.tpm_limit` and `rpm_limit` into the global rate limiter's default bucket
- Call `configure_from_llm_config()` at the end of `load_llm_config_async()` so project config.yaml free-tier limits take effect globally
- Add missing `GlobalRateLimiter.acquire()` call to `QwenCodeClient.send_async` — the only cloud provider that bypassed rate limiting

Closes #429

## Changes

- `src/warden/llm/global_rate_limiter.py`: Added `configure_from_llm_config(config)` method that updates the `"default"` rate limiter bucket from `LlmConfiguration` values; clamps zero values to minimum of 1
- `src/warden/llm/config.py`: Added call to `grl.configure_from_llm_config(config)` at end of `load_llm_config_async()` with silent failure guard so config loading never crashes due to rate limiter errors
- `src/warden/llm/providers/qwencode.py`: Added `GlobalRateLimiter.acquire("qwen", tokens=...)` before HTTP call, matching the pattern used by all other cloud providers
- `tests/llm/test_rate_limiting_429.py`: 10 new unit tests covering `configure_from_llm_config`, `QwenCodeClient` rate-limit integration, and `load_llm_config_async` wiring

## Test

- `py_compile` passed on all modified files
- All 10 new tests pass
- Full `tests/llm/` suite: 322 passed (excluding live network tests)