### PR TITLE
fix(classification): lower SKIP_LLM_THRESHOLD from 0.88 to 0.82

### DIFF
--- a/src/warden/classification/application/heuristic_classifier.py
+++ b/src/warden/classification/application/heuristic_classifier.py
@@ -37,7 +37,7 @@ logger = get_logger(__name__)
 
 # Confidence threshold above which the LLM call is skipped.
 # Keep below 1.0 so that an unknown/complex file always gets LLM review.
-SKIP_LLM_THRESHOLD = 0.88
+SKIP_LLM_THRESHOLD = 0.82
 
 
 @dataclass


### PR DESCRIPTION
## Summary
Fixes #496

## Changes
- SKIP_LLM_THRESHOLD: 0.88 → 0.82
- Non-security projects now skip LLM classification (confidence 0.83 >= 0.82)
- Security-sensitive projects still go to LLM (cap 0.81 < 0.82)

## Verify
- verify suite: 45/45 PASS
- Multi-file non-security project: skip_llm=True (was always False)