### PR TITLE
fix(pipeline): remove fortification override in STANDARD level

### DIFF
--- a/src/warden/pipeline/application/orchestrator/orchestrator.py
+++ b/src/warden/pipeline/application/orchestrator/orchestrator.py
@@ -272,9 +272,9 @@ class PhaseOrchestrator:
                     logger.info("basic_level_overrides_applied", use_llm=False, fortification=False, cleaning=False)
                 elif self.config.analysis_level == AnalysisLevel.STANDARD:
                     self.config.use_llm = True
-                    self.config.enable_fortification = True
                     self.config.enable_issue_validation = True
-                    logger.info("standard_level_overrides_applied", use_llm=True, fortification=True, verification=True)
+                    # Fortification stays at config default (False) — only DEEP enables it
+                    logger.info("standard_level_overrides_applied", use_llm=True, verification=True)
                 elif self.config.analysis_level == AnalysisLevel.DEEP:
                     self.config.use_llm = True
                     self.config.enable_fortification = True


### PR DESCRIPTION
## Summary
Fixes #529

## Problem
`analysis_level='standard'` was overriding `enable_fortification=True`, ignoring user's `PipelineConfig(enable_fortification=False)`. Caused 30-60s extra LLM calls and pipeline timeouts.

## Fix
Remove `enable_fortification = True` from STANDARD override. Only DEEP level enables it.

## Live Test
```
WARDEN_LLM_PROVIDER=groq warden scan verify/corpus/python_sqli.py --level standard
→ ❌ Scan failed: 2 critical issues found
→ Qwen Analysis: SQL injection via f-string formatting
```

## Verify
- Compile: OK
- verify suite: 45/45 PASS