### PR TITLE
feat(llm): make per-provider rate limits configurable via config.yaml

### DIFF
--- a/src/warden/llm/config.py
+++ b/src/warden/llm/config.py
@@ -109,6 +109,11 @@ class LlmConfiguration:
     tpm_limit: int = 1000  # Tokens per minute (free-tier default)
     rpm_limit: int = 6  # Requests per minute (free-tier default)
 
+    # Per-provider rate limit overrides from config.yaml.
+    # Keys: provider name (e.g. "openai", "groq") → {"tpm": int, "rpm": int}
+    # Takes precedence over the hard-coded defaults in GlobalRateLimiter.
+    provider_rate_limits: dict[str, dict[str, int]] | None = None
+
     # Centralized token budgets for all LLM consumers (triage-aware).
     # Keys: category name → {"deep": int, "fast": int}
     # Overrides built-in defaults in warden.shared.utils.llm_context.DEFAULT_TOKEN_BUDGETS.
@@ -631,6 +636,23 @@ async def load_llm_config_async(config_override: dict | None = None) -> LlmConfi
         if "rpm_limit" in config_override:
             with contextlib.suppress(ValueError, TypeError):
                 config.rpm_limit = int(config_override["rpm_limit"])
+
+        # Per-provider rate limit overrides from config.yaml
+        if "provider_rate_limits" in config_override:
+            raw_prl = config_override["provider_rate_limits"]
+            if isinstance(raw_prl, dict):
+                parsed_prl: dict[str, dict[str, int]] = {}
+                for prov_key, limits in raw_prl.items():
+                    if isinstance(limits, dict):
+                        parsed_limits: dict[str, int] = {}
+                        for limit_key in ("tpm", "rpm"):
+                            if limit_key in limits:
+                                with contextlib.suppress(ValueError, TypeError):
+                                    parsed_limits[limit_key] = int(limits[limit_key])
+                        if parsed_limits:
+                            parsed_prl[prov_key] = parsed_limits
+                if parsed_prl:
+                    config.provider_rate_limits = parsed_prl
 
         # Smart tier provider override from config.yaml (env var takes precedence)
         if "smart_tier_provider" in config_override and not config.smart_tier_provider:

--- a/src/warden/llm/global_rate_limiter.py
+++ b/src/warden/llm/global_rate_limiter.py
@@ -153,10 +153,9 @@ class GlobalRateLimiter:
         ``"default"`` bucket so that project-level config.yaml settings
         (e.g. free-tier 6 rpm / 1000 tpm) take effect globally.
 
-        Provider-specific limiters (openai, anthropic, …) are intentionally
-        left unchanged — they reflect the provider's own published limits.
-        Projects that need stricter per-provider control can extend this
-        method in the future.
+        If ``config.provider_rate_limits`` is set, also updates the matching
+        provider-specific buckets.  Unknown provider keys are silently ignored
+        (they will receive the default bucket at runtime).
 
         Args:
             config: Loaded LlmConfiguration instance.
@@ -169,6 +168,24 @@ class GlobalRateLimiter:
             tpm_limit=tpm,
             rpm_limit=rpm,
         )
+
+        # Update provider-specific limits from config if provided
+        provider_limits = getattr(config, "provider_rate_limits", None)
+        if provider_limits and isinstance(provider_limits, dict):
+            for provider_key, limits in provider_limits.items():
+                if provider_key in self._limiters:
+                    existing = self._limiters[provider_key]
+                    new_tpm = limits.get("tpm", existing.config.tpm)
+                    new_rpm = limits.get("rpm", existing.config.rpm)
+                    self._limiters[provider_key] = RateLimiter(
+                        RateLimitConfig(tpm=new_tpm, rpm=new_rpm)
+                    )
+                    _logger.info(
+                        "provider_rate_limit_configured",
+                        provider=provider_key,
+                        tpm=new_tpm,
+                        rpm=new_rpm,
+                    )
 
     def get_stats(self, provider: str = "default") -> dict:
         """


### PR DESCRIPTION
## Summary
Per-provider rate limits (TPM/RPM) were hard-coded. Now configurable via config.yaml.

## Changes
- `LlmConfiguration`: add `provider_rate_limits` optional field
- `GlobalRateLimiter.configure_from_llm_config()`: apply provider-specific overrides

## Usage
```yaml
llm:
  provider_rate_limits:
    groq:
      tpm: 6000
      rpm: 30
    openai:
      tpm: 60000
      rpm: 50
```

## Verify
- Compile: OK