### PR TITLE
fix(config): wire min_severity and classification_config to PipelineConfig

### DIFF
--- a/src/warden/cli_bridge/handlers/config_handler.py
+++ b/src/warden/cli_bridge/handlers/config_handler.py
@@ -144,6 +144,8 @@ class ConfigHandler(BaseHandler):
                 llm_config=config_data.get("llm"),
                 enable_issue_validation=settings.get("enable_issue_validation", True),
                 use_gitignore=settings.get("use_gitignore", True),
+                min_severity=settings.get("min_severity", "low"),
+                classification_config=settings.get("classification_config", None),
                 discovery_config=settings.get("discovery_config", None),
                 global_rules=global_rules_objects,
                 frame_rules=pipeline_frame_rules,

--- a/src/warden/pipeline/domain/models.py
+++ b/src/warden/pipeline/domain/models.py
@@ -85,7 +85,11 @@ class PipelineConfig(BaseDomainModel):
     enable_suppression: bool = True  # Apply suppression filtering after validation
     enable_issue_validation: bool = True  # Apply confidence-based false positive detection
 
+    # Filtering
+    min_severity: str = "low"  # Minimum severity threshold for reporting (low/medium/high/critical)
+
     # Phase-specific configurations
+    classification_config: dict[str, Any] | None = None  # Classification phase configuration
     discovery_config: dict[str, Any] | None = None  # Discovery configuration options
 
     # PRE-ANALYSIS configuration (NEW!)


### PR DESCRIPTION
## Summary
- Add `min_severity` and `classification_config` fields to `PipelineConfig`
- Wire them from `config_handler.py` settings dict
- Previously written by `warden init` but silently ignored on read

## Chaos analysis
- **What if min_severity has invalid value?** Pydantic accepts any string; downstream consumers should validate
- **Backward compat?** Both fields have defaults matching previous behavior (`low`, `None`)

## Test plan
- [x] `py_compile` passes for both files
- [x] PipelineConfig accepts new fields with correct defaults
- [x] 127 config-related tests pass

Closes #535