### PR TITLE
fix(diff): map old_path for renamed files in diff line filter

### DIFF
--- a/src/warden/cli/commands/scan.py
+++ b/src/warden/cli/commands/scan.py
@@ -337,9 +337,9 @@ def scan_command(
                             added = file_diff.get_all_added_lines()
                             if added:
                                 diff_changed_lines[file_diff.file_path] = added
-                                # Map old path too so findings referencing pre-rename path aren't dropped
-                                if file_diff.old_path and file_diff.old_path != file_diff.file_path:
-                                    diff_changed_lines[file_diff.old_path] = added
+                            # Map old path for renames regardless of added lines
+                            if file_diff.old_path and file_diff.old_path != file_diff.file_path:
+                                diff_changed_lines[file_diff.old_path] = added or set()
                         # Ensure files with only deletions are in the map (empty set = drop all findings)
                         for f in changed_files:
                             rel = str(Path(f).resolve().relative_to(Path.cwd().resolve())) if Path(f).is_absolute() else f


### PR DESCRIPTION
## Summary
- When files are renamed, `git diff` returns the new path
- Findings may reference the old path → silently dropped by diff filter
- Now both `old_path` and `file_path` are mapped in `diff_changed_lines`

## Chaos analysis
- **What if old_path is None?** Guarded by `if file_diff.old_path`
- **What if old_path == file_path?** Checked with `!=` — no duplicate entry
- **Backward compat?** No change for non-rename diffs

## Test plan
- [x] `py_compile` passes
- [x] Simulated rename diff → both old and new path in map
- [x] Non-rename diffs unaffected

Closes #522