### PR TITLE
chore(config): map useful advanced keys as settings fallbacks

### DIFF
--- a/src/warden/cli_bridge/handlers/config_handler.py
+++ b/src/warden/cli_bridge/handlers/config_handler.py
@@ -91,10 +91,16 @@ class ConfigHandler(BaseHandler):
             frames = self._select_frames(frame_names, frame_map, available_frames)
             self.active_config_name = config_data.get("name", "project-config")
 
-        settings = config_data.get("settings", {})
+        settings = config_data.get("settings") or {}
+        if not isinstance(settings, dict):
+            logger.warning("settings_not_a_dict", value=type(settings).__name__)
+            settings = {}
 
         # Merge useful advanced keys as fallbacks (advanced section is semi-deprecated)
-        advanced = config_data.get("advanced", {})
+        advanced = config_data.get("advanced") or {}
+        if not isinstance(advanced, dict):
+            logger.warning("advanced_not_a_dict", value=type(advanced).__name__)
+            advanced = {}
         if advanced:
             if "max_workers" in advanced and "parallel_limit" not in settings:
                 settings["parallel_limit"] = advanced["max_workers"]


### PR DESCRIPTION
## Summary
- `advanced.max_workers` → `parallel_limit` (fallback, settings takes precedence)
- `advanced.frame_timeout` → `frame_timeout` (fallback, settings takes precedence)
- Other dead advanced keys (`debug`, `fail_on_blocker`) remain unmapped — not useful

## Test plan
- [x] `py_compile` passes
- [x] Advanced keys merge correctly when settings empty
- [x] Settings takes precedence over advanced
- [x] Empty advanced dict is no-op

Closes #537