### PR TITLE
fix(pipeline): totalFrames reports executed count, not registry size

### DIFF
--- a/src/warden/pipeline/application/orchestrator/pipeline_result_builder.py
+++ b/src/warden/pipeline/application/orchestrator/pipeline_result_builder.py
@@ -74,9 +74,8 @@ class PipelineResultBuilder:
         frames_skipped = 0
 
         actual_total = frames_passed + frames_failed + frames_skipped
-        planned_total = len(getattr(context, "selected_frames", [])) or len(self.frames)
         executed_count = len(frame_results)
-        total_frames = max(actual_total, planned_total, executed_count)
+        total_frames = max(actual_total, executed_count)
 
         return PipelineResult(
             pipeline_id=context.pipeline_id,


### PR DESCRIPTION
Fixes #564

## Changes
- Remove `planned_total` (classification selection count) from `total_frames` calculation
- `total_frames = max(actual_total, executed_count)` — matches `frameResults` array

## Verify
- `total_frames: 9` = `frameResults: 9` (was 13 vs 9)
- warden verify: PASS
- py_compile: PASS