### PR TITLE
fix(score): normalize unknown severity to low instead of zero penalty

### DIFF
--- a/src/warden/shared/utils/finding_utils.py
+++ b/src/warden/shared/utils/finding_utils.py
@@ -48,7 +48,11 @@ def set_finding_attribute(finding: Any, attr: str, value: Any) -> None:
         pass
 
 
+_KNOWN_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+
+
 def get_finding_severity(finding: Any) -> str:
-    """Safely gets normalized severity."""
+    """Safely gets normalized severity. Unknown values map to 'low'."""
     sev = get_finding_attribute(finding, "severity", "medium")
-    return str(sev).lower() if sev else "medium"
+    normalized = str(sev).lower() if sev else "medium"
+    return normalized if normalized in _KNOWN_SEVERITIES else "low"


### PR DESCRIPTION
Fixes #574. Unknown severity strings (warning/info/error) now map to 'low' (0.1 penalty) instead of falling through all buckets with zero contribution.