### PR TITLE
fix(init): sync root.yaml frame_rules with config.yaml frames list

### DIFF
--- a/src/warden/cli/commands/init_steps.py
+++ b/src/warden/cli/commands/init_steps.py
@@ -252,13 +252,16 @@ frame_rules:
       - no-secrets
     on_fail: stop
 
+  resilience:
+    on_fail: continue
+
   orphan:
     on_fail: continue
 
-  architecture:
+  fuzz:
     on_fail: continue
 
-  resilience:
+  property:
     on_fail: continue
 """
     root_yaml_path.write_text(content, encoding="utf-8")


### PR DESCRIPTION
root.yaml had architecture (not in config) and missed fuzz/property (in config) → frame_consistency warnings on every scan. Now synced.