### PR TITLE
fix(scan): eliminate all warning noise in basic mode

### DIFF
--- a/src/warden/analysis/application/analysis_phase.py
+++ b/src/warden/analysis/application/analysis_phase.py
@@ -139,7 +139,7 @@ class AnalysisPhase:
             import json
 
             self._cache_file.parent.mkdir(parents=True, exist_ok=True)
-            self._cache_file.write_text(json.dumps(self._cache_data, indent=2))
+            self._cache_file.write_text(json.dumps(self._cache_data, indent=2, default=str))
         except Exception as e:
             logger.warning("analysis_cache_save_failed", error=str(e))
 

--- a/src/warden/analysis/application/pre_analysis_phase.py
+++ b/src/warden/analysis/application/pre_analysis_phase.py
@@ -298,7 +298,7 @@ class PreAnalysisPhase:
             # Validate Environment Hash
             is_env_valid = self._validate_environment_hash()
             if not is_env_valid:
-                logger.warning(
+                logger.info(
                     "environment_changed", reason="config_or_version_mismatch", action="invalidating_context_cache"
                 )
 

--- a/src/warden/pipeline/application/orchestrator/frame_matcher.py
+++ b/src/warden/pipeline/application/orchestrator/frame_matcher.py
@@ -249,7 +249,7 @@ class FrameMatcher:
                     ai_frames.append(frame)
                     logger.debug("ai_selected_frame", frame_id=frame.frame_id, source="classification")
                 else:
-                    logger.warning(f"Could not match frame: {selected_name}")
+                    logger.debug("classification_frame_not_matched", name=selected_name)
 
             # STEP 2: Collect user-enforced frames (explicit enabled: true)
             # Skip when CLI --frame override is active (CLI = exact set, no extras)

--- a/src/warden/pipeline/application/orchestrator/frame_runner.py
+++ b/src/warden/pipeline/application/orchestrator/frame_runner.py
@@ -292,7 +292,8 @@ class FrameRunner:
             )
             return skip_result
 
-        if self.llm_service:
+        use_llm = getattr(self.config, "use_llm", True) if self.config else True
+        if self.llm_service and use_llm:
             frame.llm_service = self.llm_service
             # Enable agentic loop with project context
             project_root = getattr(context, "project_root", None) or Path.cwd()

--- a/src/warden/reports/generator.py
+++ b/src/warden/reports/generator.py
@@ -671,7 +671,7 @@ class ReportGenerator:
         if not badge_secret:
             from warden.shared.infrastructure.logging import get_logger as _get_logger
 
-            _get_logger(__name__).warning(
+            _get_logger(__name__).debug(
                 "badge_secret_not_set",
                 message="WARDEN_BADGE_SECRET env var not set. Badge signature uses weak default. "
                 "Set WARDEN_BADGE_SECRET for production use.",

--- a/src/warden/shared/infrastructure/config.py
+++ b/src/warden/shared/infrastructure/config.py
@@ -127,7 +127,7 @@ class Settings(BaseSettings):
             else:
                 # Auto-generate in dev mode with loud warning
                 self.secret_key = secrets.token_urlsafe(32)
-                logger.warning(
+                logger.debug(
                     "auto_generated_secret_key",
                     message="SECRET_KEY was empty. Auto-generated a random key for development. "
                     "Set SECRET_KEY in .env for production use.",

--- a/src/warden/validation/application/rust_validation_engine.py
+++ b/src/warden/validation/application/rust_validation_engine.py
@@ -40,7 +40,7 @@ class RustValidationEngine:
     async def load_rules_from_yaml_async(self, yaml_path: Path) -> None:
         """Load global rules from a YAML file (Async)."""
         if not RUST_AVAILABLE:
-            logger.warning("rust_unavailable_skipping_rules", path=str(yaml_path))
+            logger.debug("rust_unavailable_skipping_rules", path=str(yaml_path))
             return
 
         try:


### PR DESCRIPTION
## Before: 15+ warnings per scan
- Ollama connection failures ×6 (LLM disabled but client still injected)
- auto_generated_secret_key ×2
- badge_secret_not_set
- rust_unavailable_skipping_rules
- Could not match frame: stress
- analysis_cache_save_failed
- environment_changed

## After: 0 warning logs
Only UX info message: "Basic Mode — AI verification disabled"

## Changes
- `frame_runner.py`: skip LLM service injection when `use_llm=False`
- `frame_matcher.py`: unmatched frame → debug (not warning)
- `analysis_phase.py`: `json.dumps(default=str)` for cache serialization
- `rust_validation_engine.py`: optional dep → debug
- `generator.py`: badge secret → debug  
- `config.py`: auto secret key → debug
- `pre_analysis_phase.py`: env cache invalidation → info