### PR TITLE
fix(score): calculate quality score from pre-baseline findings

### DIFF
--- a/src/warden/cli/commands/scan_output.py
+++ b/src/warden/cli/commands/scan_output.py
@@ -224,8 +224,10 @@ def _render_text_report(
     )
 
     baseline_info = res.get("baseline_update", {})
-    technical_debt = baseline_info.get("total_debt", total_findings)
-    new_debt_added = baseline_info.get("new_debt", total_findings)
+    baseline_suppressed = res.get("baseline_suppressed_count", 0)
+    total_pre_baseline = res.get("total_findings_pre_baseline", total_findings)
+    technical_debt = baseline_info.get("total_debt", 0)
+    new_debt_added = baseline_info.get("new_debt", 0)
 
     # Fallback: try pipeline summary fields when no findings objects exist
     if total_findings == 0:
@@ -446,13 +448,12 @@ def _render_text_report(
         "Quality issues",
         f"[bold white]{quality_issues}[/]",
     )
-    if technical_debt > 0 or new_debt_added > 0:
-        new_debt_col = "red" if new_debt_added > 0 else "green"
+    if baseline_suppressed > 0 or technical_debt > 0 or new_debt_added > 0:
         stat_table.add_row(
-            "Technical debt",
-            f"[bold white]{technical_debt}[/]",
-            "New debt",
-            f"[bold {new_debt_col}]{'+' if new_debt_added > 0 else ''}{new_debt_added}[/]",
+            "Existing debt",
+            f"[bold yellow]{baseline_suppressed}[/]",
+            "New findings",
+            f"[bold {'red' if total_findings > 0 else 'green'}]{total_findings}[/]",
         )
 
     duration_str = f"{scan_duration:.1f}s" if scan_duration > 0 else "—"

--- a/src/warden/pipeline/application/orchestrator/findings_post_processor.py
+++ b/src/warden/pipeline/application/orchestrator/findings_post_processor.py
@@ -264,6 +264,9 @@ class FindingsPostProcessor:
 
             logger.info("baseline_loaded", known_issues_count=len(known_issues))
 
+            # Snapshot ALL findings before baseline filtering — quality score uses this
+            context.all_findings_pre_baseline = list(context.findings) if context.findings else []
+
             total_suppressed = 0
 
             for _fid, f_res in context.frame_results.items():
@@ -299,6 +302,8 @@ class FindingsPostProcessor:
                     and not self._has_blocker_violations(result_obj)
                 ):
                     result_obj.status = "passed"
+
+            context.baseline_suppressed_count = total_suppressed
 
             if total_suppressed > 0:
                 logger.info("baseline_applied", suppressed_issues=total_suppressed)

--- a/src/warden/pipeline/application/orchestrator/pipeline_result_builder.py
+++ b/src/warden/pipeline/application/orchestrator/pipeline_result_builder.py
@@ -56,7 +56,10 @@ class PipelineResultBuilder:
         if not base_score or base_score <= 0.0:
             base_score = calculate_base_score(getattr(context, "linter_metrics", None))
 
-        quality_score = calculate_quality_score(findings, base_score)
+        # Score uses ALL findings (pre-baseline) to reflect actual code health.
+        # CI gate uses post-baseline findings (new regressions only).
+        all_findings_for_score = getattr(context, "all_findings_pre_baseline", None) or findings
+        quality_score = calculate_quality_score(all_findings_for_score, base_score)
         context.quality_score_after = quality_score
 
         # Count blocker violations from pre/post custom rules
@@ -93,6 +96,8 @@ class PipelineResultBuilder:
             low_findings=low_findings,
             manual_review_findings=manual_review_count,
             blocker_violations=blocker_violations,
+            baseline_suppressed_count=getattr(context, "baseline_suppressed_count", 0),
+            total_findings_pre_baseline=len(all_findings_for_score),
             findings=[f if isinstance(f, dict) else f.to_dict() for f in findings],
             frame_results=frame_results,
             metadata={

--- a/src/warden/pipeline/domain/models.py
+++ b/src/warden/pipeline/domain/models.py
@@ -286,6 +286,10 @@ class PipelineResult(BaseDomainModel):
     artifacts: list[dict[str, Any]] = Field(default_factory=list)
     quality_score: float = 0.0
 
+    # Baseline debt metrics
+    baseline_suppressed_count: int = 0
+    total_findings_pre_baseline: int = 0
+
     # Blocker violations from custom rules (is_blocker: true)
     blocker_violations: int = 0
 
@@ -367,6 +371,8 @@ class PipelineResult(BaseDomainModel):
         data["low_findings"] = self.low_findings
         data["manual_review_findings"] = self.manual_review_findings
         data["quality_score"] = rounded_score
+        data["baseline_suppressed_count"] = self.baseline_suppressed_count
+        data["total_findings_pre_baseline"] = self.total_findings_pre_baseline
 
         return data
 

--- a/src/warden/pipeline/domain/pipeline_context.py
+++ b/src/warden/pipeline/domain/pipeline_context.py
@@ -218,6 +218,11 @@ class PipelineContext:
     # Each entry: {id, file, title, severity, matched_rule, matched_files, timestamp}
     suppressed_findings: list[dict[str, Any]] = field(default_factory=list)
 
+    # Baseline: pre-filter snapshot for quality scoring
+    all_findings_pre_baseline: list[dict[str, Any]] = field(default_factory=list)
+    baseline_suppressed_count: int = 0
+    baseline_resolved_count: int = 0
+
     # Phase 4: FORTIFICATION Results
     fortifications: list[dict[str, Any]] = field(default_factory=list)
     applied_fixes: list[dict[str, Any]] = field(default_factory=list)


### PR DESCRIPTION
## Problem
Quality score was calculated AFTER baseline filtering. Second scan with no code changes → 0 findings → score 10.0/10. But 20+ issues still exist in the code.

## Fix
- Snapshot `all_findings_pre_baseline` before `apply_baseline()` mutates `context.findings`
- `calculate_quality_score()` now uses pre-baseline findings (actual code health)
- CI gate still uses post-baseline findings (only blocks regressions)
- New fields: `baseline_suppressed_count`, `total_findings_pre_baseline`
- CLI stat table shows "Existing debt" vs "New findings"

## Verification
```
Scan 1: 123 findings, score 2.6/10
Scan 2 (no changes): 123 findings, score 2.6/10  ← was 10.0 before fix
```

## Data flow
```
apply_baseline():
  1. context.all_findings_pre_baseline = [123 findings]  ← snapshot
  2. context.findings = [post-filter]                     ← for CI gate
  3. context.baseline_suppressed_count = N

result_builder.build():
  quality_score = calculate(all_findings_pre_baseline)    ← actual code health
  total_findings = len(findings)                          ← new regressions only
```