### PR TITLE
fix(llm): temperature=0.0 for triage + fix LSP c.location bug

### DIFF
--- a/src/warden/analysis/application/triage_service.py
+++ b/src/warden/analysis/application/triage_service.py
@@ -270,7 +270,7 @@ FILES:
             system_prompt=self.BATCH_SYSTEM_PROMPT,
             user_message=prompt,
             use_fast_tier=True,
-            temperature=0.01,
+            temperature=0.0,
             max_tokens=min(2000, 300 * len(code_files)),
             timeout_seconds=45.0,  # Triage is simple classification; 45s is ample.
         )
@@ -329,7 +329,7 @@ FILES:
             system_prompt=self.SYSTEM_PROMPT,
             user_message=prompt,
             use_fast_tier=True,
-            temperature=0.1,
+            temperature=0.0,
             max_tokens=250,
             timeout_seconds=45.0,  # Triage is simple classification; 45s is ample.
         )

--- a/src/warden/validation/frames/resilience/resilience_frame.py
+++ b/src/warden/validation/frames/resilience/resilience_frame.py
@@ -625,7 +625,7 @@ class ResilienceFrame(ValidationFrame, TaintAware, ChunkingAware):
                     )
                     if callers:
                         context.callers.extend(
-                            [{"name": c.name, "file": c.location} for c in callers[: context.MAX_CALLERS_IN_CONTEXT]]
+                            [{"name": c.name, "file": c.file_path} for c in callers[: context.MAX_CALLERS_IN_CONTEXT]]
                         )
 
                     # Get callees with timeout
@@ -635,7 +635,7 @@ class ResilienceFrame(ValidationFrame, TaintAware, ChunkingAware):
                     )
                     if callees:
                         context.callees.extend(
-                            [{"name": c.name, "file": c.location} for c in callees[: context.MAX_CALLEES_IN_CONTEXT]]
+                            [{"name": c.name, "file": c.file_path} for c in callees[: context.MAX_CALLEES_IN_CONTEXT]]
                         )
 
                 except (asyncio.TimeoutError, TimeoutError):

--- a/src/warden/validation/frames/security/data_flow_analyzer.py
+++ b/src/warden/validation/frames/security/data_flow_analyzer.py
@@ -59,7 +59,7 @@ async def analyze_data_flow(code_file: Any, findings: list[Any]) -> dict[str, An
                         {
                             "vulnerable_at": f"{code_file.path}:{location['line']}",
                             "called_from": c.name,
-                            "caller_file": c.location,
+                            "caller_file": c.file_path,
                             "finding_type": location.get("type", "unknown"),
                         }
                         for c in callers[:3]
@@ -79,7 +79,7 @@ async def analyze_data_flow(code_file: Any, findings: list[Any]) -> dict[str, An
                         {
                             "vulnerable_at": f"{code_file.path}:{location['line']}",
                             "data_from": c.name,
-                            "source_file": c.location,
+                            "source_file": c.file_path,
                             "finding_type": location.get("type", "unknown"),
                         }
                         for c in callees[:3]


### PR DESCRIPTION
## Quick wins for LLM consistency

### Changes
- **Temperature fix**: Triage batch `0.01→0.0`, single `0.1→0.0`
- **LSP bug fix**: `c.location` → `c.file_path` in 4 locations (was AttributeError, silently swallowed)

### Impact
- Triage routing now deterministic (same file → same lane every time)
- LSP caller/callee context now reaches LLM prompts (was lost to silent exception)
- Basic scan: 179 findings, 0 regression

### Pareto reasoning
These are the simplest possible fixes (6 lines changed) with highest consistency impact.
No new features, no architecture changes, no risk.